### PR TITLE
feat(blog): RU backfill workflow + admin audit history

### DIFF
--- a/app/admin/blog/page.tsx
+++ b/app/admin/blog/page.tsx
@@ -5,12 +5,14 @@ import { ArrowLeft, Bot, Sparkles } from "lucide-react";
 import {
   createBlogPostFromDeepResearchAction,
   logoutAdminAction,
+  runRuBlogBackfillAction,
 } from "@/app/admin/actions";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import { getRecentBlogRuBackfillRuns } from "@/lib/blog/backfill";
 import { tr } from "@/lib/i18n";
 import { getLocale } from "@/lib/i18n-server";
 
@@ -26,6 +28,13 @@ type AdminBlogPageProps = {
     slug?: string;
     research?: string;
     sources?: string;
+    backfillChanged?: string;
+    backfillApplied?: string;
+    backfillErrors?: string;
+    backfillTableChanged?: string;
+    backfillStorageChanged?: string;
+    backfillLimit?: string;
+    backfillRunId?: string;
   }>;
 };
 
@@ -41,9 +50,76 @@ function formatError(error?: string) {
   return error;
 }
 
+function parseCounter(value?: string): number {
+  const parsed = Number.parseInt(value ?? "", 10);
+  return Number.isFinite(parsed) ? Math.max(0, parsed) : 0;
+}
+
+function formatRunDate(isoDate: string, locale: "en" | "ru"): string {
+  try {
+    return new Intl.DateTimeFormat(locale === "ru" ? "ru-RU" : "en-US", {
+      dateStyle: "medium",
+      timeStyle: "short",
+    }).format(new Date(isoDate));
+  } catch {
+    return isoDate;
+  }
+}
+
+function statusLabel(locale: "en" | "ru", status: "success" | "partial" | "failed"): string {
+  if (status === "success") {
+    return tr(locale, "Success", "Успех");
+  }
+
+  if (status === "partial") {
+    return tr(locale, "Partial", "Частично");
+  }
+
+  return tr(locale, "Failed", "Ошибка");
+}
+
+function statusToneClass(status: "success" | "partial" | "failed"): string {
+  if (status === "success") {
+    return "border-emerald-400/35 bg-emerald-500/10 text-emerald-200";
+  }
+
+  if (status === "partial") {
+    return "border-amber-400/35 bg-amber-500/10 text-amber-200";
+  }
+
+  return "border-rose-400/35 bg-rose-500/10 text-rose-200";
+}
+
 export default async function AdminBlogPage({ searchParams }: AdminBlogPageProps) {
   const locale = await getLocale();
-  const { success, error, slug, research, sources } = await searchParams;
+  const {
+    success,
+    error,
+    slug,
+    research,
+    sources,
+    backfillChanged,
+    backfillApplied,
+    backfillErrors,
+    backfillTableChanged,
+    backfillStorageChanged,
+    backfillLimit,
+    backfillRunId,
+  } = await searchParams;
+
+  let backfillHistory = {
+    available: false,
+    runs: [] as Awaited<ReturnType<typeof getRecentBlogRuBackfillRuns>>["runs"],
+  };
+
+  try {
+    backfillHistory = await getRecentBlogRuBackfillRuns(8);
+  } catch {
+    backfillHistory = {
+      available: false,
+      runs: [],
+    };
+  }
 
   const successMessage =
     success === "created"
@@ -52,12 +128,20 @@ export default async function AdminBlogPage({ searchParams }: AdminBlogPageProps
           `Post created: ${slug}. Deep research packet: ${research}. Sources used: ${sources}.`,
           `Статья создана: ${slug}. Пакет deep research: ${research}. Использовано источников: ${sources}.`,
         )
-      : null;
+      : success === "backfill"
+        ? tr(
+            locale,
+            `RU backfill completed. Changed: ${parseCounter(backfillChanged)}, applied: ${parseCounter(backfillApplied)}, errors: ${parseCounter(backfillErrors)}. Table changed: ${parseCounter(backfillTableChanged)}. Storage changed: ${parseCounter(backfillStorageChanged)}. Limit: ${parseCounter(backfillLimit)}.${backfillRunId ? ` Run ID: ${backfillRunId}.` : ""}`,
+            `RU backfill завершён. Изменено: ${parseCounter(backfillChanged)}, применено: ${parseCounter(backfillApplied)}, ошибок: ${parseCounter(backfillErrors)}. Изменено в таблице: ${parseCounter(backfillTableChanged)}. Изменено в storage: ${parseCounter(backfillStorageChanged)}. Лимит: ${parseCounter(backfillLimit)}.${backfillRunId ? ` Run ID: ${backfillRunId}.` : ""}`,
+          )
+        : null;
 
   const errorMessage = error ? tr(locale, formatError(error) ?? error, formatError(error) ?? error) : null;
 
   return (
-    <div className="mx-auto w-full max-w-6xl px-4 py-10 sm:px-6">
+    <div className="relative overflow-hidden border-t border-white/10">
+      <div className="pointer-events-none absolute inset-0 -z-10 bg-[linear-gradient(180deg,#060a14_0%,#070c18_48%,#050913_100%)]" />
+      <div className="mx-auto w-full max-w-6xl px-4 py-10 sm:px-6">
       <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
         <div>
           <h1 className="text-2xl font-semibold text-slate-100">
@@ -269,8 +353,95 @@ export default async function AdminBlogPage({ searchParams }: AdminBlogPageProps
                 "Укажите EXA_API_KEY в переменных окружения. Без этого автоматизация статьи не запустится.",
               )}
             </p>
+
+            <div className="space-y-2 rounded-md border border-cyan-400/25 bg-cyan-500/10 p-3">
+              <p className="text-xs font-medium uppercase tracking-wide text-cyan-200">
+                {tr(locale, "RU copy maintenance", "Обслуживание RU-копии")}
+              </p>
+              <p className="text-xs text-slate-300">
+                {tr(
+                  locale,
+                  "Runs a one-time normalization pass for legacy deep-research auto-posts (table + storage).",
+                  "Запускает разовую нормализацию legacy deep-research автопостов (таблица + storage).",
+                )}
+              </p>
+
+              <form action={runRuBlogBackfillAction} className="space-y-2">
+                <div className="space-y-1.5">
+                  <Label htmlFor="backfillLimit">{tr(locale, "Scan limit", "Лимит сканирования")}</Label>
+                  <Input
+                    id="backfillLimit"
+                    name="backfillLimit"
+                    type="number"
+                    min={1}
+                    max={5000}
+                    defaultValue={500}
+                    className="border-white/10 bg-slate-950/80"
+                  />
+                </div>
+
+                <Button type="submit" className="w-full bg-cyan-500 text-slate-950 hover:bg-cyan-400">
+                  {tr(locale, "Run RU backfill now", "Запустить RU backfill сейчас")}
+                </Button>
+              </form>
+
+              <div className="rounded-md border border-white/10 bg-slate-950/60 p-3">
+                <p className="text-xs font-medium uppercase tracking-wide text-slate-100">
+                  {tr(locale, "Recent backfill runs", "Последние backfill-запуски")}
+                </p>
+
+                {backfillHistory.available ? (
+                  backfillHistory.runs.length > 0 ? (
+                    <ul className="mt-2 space-y-2">
+                      {backfillHistory.runs.map((run) => (
+                        <li key={run.id} className="rounded-md border border-white/10 bg-white/[0.02] p-2">
+                          <div className="flex flex-wrap items-center justify-between gap-2">
+                            <span
+                              className={`inline-flex rounded-full border px-2 py-0.5 text-[11px] font-medium ${statusToneClass(run.status)}`}
+                            >
+                              {statusLabel(locale, run.status)}
+                            </span>
+
+                            <span className="text-[11px] text-slate-400">{formatRunDate(run.createdAt, locale)}</span>
+                          </div>
+
+                          <p className="mt-1 text-[11px] text-slate-300">
+                            {tr(
+                              locale,
+                              `Changed ${run.changed}, applied ${run.applied}, errors ${run.errors}, table ${run.table.changed}, storage ${run.storage.changed}, limit ${run.scanLimit}.`,
+                              `Изменено ${run.changed}, применено ${run.applied}, ошибок ${run.errors}, таблица ${run.table.changed}, storage ${run.storage.changed}, лимит ${run.scanLimit}.`,
+                            )}
+                          </p>
+
+                          <p className="mt-1 text-[11px] text-slate-500">
+                            {tr(locale, "Run ID", "Run ID")}: {run.id}
+                          </p>
+
+                          {run.errorMessage ? (
+                            <p className="mt-1 text-[11px] text-rose-300">{run.errorMessage}</p>
+                          ) : null}
+                        </li>
+                      ))}
+                    </ul>
+                  ) : (
+                    <p className="mt-2 text-[11px] text-slate-400">
+                      {tr(locale, "No backfill runs recorded yet.", "История backfill пока пустая.")}
+                    </p>
+                  )
+                ) : (
+                  <p className="mt-2 text-[11px] text-amber-200">
+                    {tr(
+                      locale,
+                      "Backfill history table is unavailable. Apply Supabase migration to enable audit log.",
+                      "Таблица истории backfill недоступна. Примените Supabase-миграцию для включения аудита.",
+                    )}
+                  </p>
+                )}
+              </div>
+            </div>
           </CardContent>
         </Card>
+      </div>
       </div>
     </div>
   );

--- a/docs/blog-automation.md
+++ b/docs/blog-automation.md
@@ -43,6 +43,15 @@ The action runs deep research + verification, then persists to Supabase:
 
 If Supabase admin credentials are unavailable in local dev, it falls back to local JSON files.
 
+`/admin/blog` also includes:
+
+- **Run RU backfill now** control for one-time normalization of legacy deep-research auto-post RU copy (table + storage)
+- **Recent backfill runs** audit list (status, counters, timestamp, run ID, optional error)
+
+To enable the audit list, apply migration:
+
+- `supabase/migrations/20260210202000_blog_backfill_runs_audit.sql`
+
 ## Scheduled auto-publishing (4+ posts/day)
 
 - Endpoint: `GET/POST /api/blog/auto-publish`
@@ -88,3 +97,21 @@ curl -X POST "https://your-domain/api/blog/auto-publish?count=1" \
 
 - Disk JSON is validated by Zod on load.
 - Supabase blog rows are validated on read; invalid rows are skipped.
+
+## RU backfill for older auto-generated posts
+
+When templates are improved, you can normalize older auto-generated RU copy in Supabase:
+
+```bash
+# preview only
+npm run blog:backfill:ru
+
+# apply changes
+npm run blog:backfill:ru -- --apply
+```
+
+What it updates (legacy auto posts only):
+
+- RU excerpt and SEO description
+- RU findings phrasing (`Сигнал N ...`)
+- RU section headings / helper text in research blocks

--- a/lib/blog/backfill.ts
+++ b/lib/blog/backfill.ts
@@ -1,0 +1,620 @@
+import type { PostgrestError, SupabaseClient } from "@supabase/supabase-js";
+
+import { createSupabaseAdminClient } from "@/lib/supabase/admin";
+
+const BLOG_STORAGE_BUCKET = "blog-automation";
+const BLOG_STORAGE_POSTS_PREFIX = "posts";
+const BACKFILL_RUNS_TABLE = "blog_backfill_runs";
+
+type LegacyPostLike = {
+  slug?: string;
+  locale?: unknown;
+  research?: unknown;
+};
+
+type BackfillRow = {
+  slug: string;
+  locale: unknown;
+  research: unknown;
+};
+
+export type BlogRuBackfillTargetStats = {
+  scanned: number;
+  legacy: number;
+  changed: number;
+  applied: number;
+  errors: number;
+  skipped: boolean;
+};
+
+export type BlogRuBackfillResult = {
+  table: BlogRuBackfillTargetStats;
+  storage: BlogRuBackfillTargetStats;
+  changed: number;
+  applied: number;
+  errors: number;
+};
+
+export type BlogRuBackfillRunStatus = "success" | "partial" | "failed";
+
+export type BlogRuBackfillRunRecord = {
+  id: string;
+  createdAt: string;
+  status: BlogRuBackfillRunStatus;
+  apply: boolean;
+  scanLimit: number;
+  table: BlogRuBackfillTargetStats;
+  storage: BlogRuBackfillTargetStats;
+  changed: number;
+  applied: number;
+  errors: number;
+  errorMessage?: string;
+};
+
+export type BlogRuBackfillRunHistory = {
+  available: boolean;
+  runs: BlogRuBackfillRunRecord[];
+};
+
+type BlogRuBackfillRunPersistInput = {
+  apply: boolean;
+  limit: number;
+  result: BlogRuBackfillResult;
+  status?: BlogRuBackfillRunStatus;
+  errorMessage?: string;
+};
+
+type BlogRuBackfillRunPersistResult = {
+  recorded: boolean;
+  runId?: string;
+};
+
+type RunBlogRuBackfillOptions = {
+  apply: boolean;
+  limit: number;
+};
+
+type NormalizeRuLocaleResult = {
+  changed: boolean;
+  locale: unknown;
+};
+
+function createEmptyStats(skipped = false): BlogRuBackfillTargetStats {
+  return {
+    scanned: 0,
+    legacy: 0,
+    changed: 0,
+    applied: 0,
+    errors: 0,
+    skipped,
+  };
+}
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isMissingBlogPostsTableError(message: string): boolean {
+  return (
+    message.includes("Could not find the table 'public.blog_posts'") ||
+    message.includes('relation "blog_posts" does not exist')
+  );
+}
+
+function isMissingBackfillRunsTableError(message: string): boolean {
+  return (
+    message.includes("Could not find the table 'public.blog_backfill_runs'") ||
+    message.includes('relation "blog_backfill_runs" does not exist')
+  );
+}
+
+function toBackfillRunStatus(result: BlogRuBackfillResult, errorMessage?: string): BlogRuBackfillRunStatus {
+  if (errorMessage) {
+    return "failed";
+  }
+
+  if (result.errors > 0) {
+    return result.applied > 0 || result.changed > 0 ? "partial" : "failed";
+  }
+
+  return "success";
+}
+
+function clampLimit(limit: number): number {
+  return Math.max(1, Math.min(limit, 5000));
+}
+
+function toFiniteNumber(value: unknown, fallback = 0): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function toBackfillTargetStats(value: unknown): BlogRuBackfillTargetStats {
+  if (!isObjectRecord(value)) {
+    return createEmptyStats(true);
+  }
+
+  const stats: BlogRuBackfillTargetStats = {
+    scanned: toFiniteNumber(value.scanned),
+    legacy: toFiniteNumber(value.legacy),
+    changed: toFiniteNumber(value.changed),
+    applied: toFiniteNumber(value.applied),
+    errors: toFiniteNumber(value.errors),
+    skipped: value.skipped === true,
+  };
+
+  return {
+    scanned: Math.max(0, stats.scanned),
+    legacy: Math.max(0, stats.legacy),
+    changed: Math.max(0, stats.changed),
+    applied: Math.max(0, stats.applied),
+    errors: Math.max(0, stats.errors),
+    skipped: stats.skipped,
+  };
+}
+
+function toBackfillRunRecord(row: Record<string, unknown>): BlogRuBackfillRunRecord | null {
+  const id = typeof row.id === "string" ? row.id : "";
+  const createdAt = typeof row.created_at === "string" ? row.created_at : "";
+  if (!id || !createdAt) {
+    return null;
+  }
+
+  const rawStatus = typeof row.status === "string" ? row.status : "failed";
+  const status: BlogRuBackfillRunStatus =
+    rawStatus === "success" || rawStatus === "partial" || rawStatus === "failed" ? rawStatus : "failed";
+
+  const apply = row.apply === true;
+  const scanLimit = Math.max(1, toFiniteNumber(row.scan_limit, 1));
+
+  const table = toBackfillTargetStats(row.table_stats);
+  const storage = toBackfillTargetStats(row.storage_stats);
+  const changed = Math.max(0, toFiniteNumber(row.changed_total));
+  const applied = Math.max(0, toFiniteNumber(row.applied_total));
+  const errors = Math.max(0, toFiniteNumber(row.error_total));
+  const errorMessage = typeof row.error_message === "string" && row.error_message.trim() ? row.error_message : undefined;
+
+  return {
+    id,
+    createdAt,
+    status,
+    apply,
+    scanLimit,
+    table,
+    storage,
+    changed,
+    applied,
+    errors,
+    errorMessage,
+  };
+}
+
+function shouldSkipBackfillRunsTable(error: PostgrestError): boolean {
+  return isMissingBackfillRunsTableError(error.message);
+}
+
+function collectRuText(post: LegacyPostLike): string {
+  if (!isObjectRecord(post.locale)) {
+    return "";
+  }
+
+  const ru = post.locale.ru;
+  if (!isObjectRecord(ru)) {
+    return "";
+  }
+
+  const excerpt = typeof ru.excerpt === "string" ? ru.excerpt : "";
+  const seoDescription = typeof ru.seoDescription === "string" ? ru.seoDescription : "";
+  const contentBlocks = Array.isArray(ru.contentBlocks) ? ru.contentBlocks : [];
+
+  const blockText = contentBlocks
+    .flatMap((block) => {
+      if (!isObjectRecord(block)) {
+        return [];
+      }
+
+      const heading = typeof block.heading === "string" ? block.heading : "";
+      const paragraphs = Array.isArray(block.paragraphs)
+        ? block.paragraphs.filter((item): item is string => typeof item === "string")
+        : [];
+
+      return [heading, ...paragraphs];
+    })
+    .filter(Boolean)
+    .join("\n");
+
+  return [excerpt, seoDescription, blockText].filter(Boolean).join("\n");
+}
+
+function hasDeepResearchProvider(post: LegacyPostLike): boolean {
+  if (!isObjectRecord(post.research)) {
+    return false;
+  }
+
+  return post.research.provider === "exa-search-deep";
+}
+
+function isLegacyAutoPost(post: LegacyPostLike): boolean {
+  if (!hasDeepResearchProvider(post)) {
+    return false;
+  }
+
+  const ruText = collectRuText(post);
+  if (!ruText) {
+    return false;
+  }
+
+  return /(по теме:|signal\s+\d+|supporting sources|repeated in \d+ independent sources|тема:\s|deep research по теме|подтверждающие источники)/i.test(
+    ruText,
+  );
+}
+
+function extractSourceIds(value: string): string[] {
+  const matched = value.match(/src-\d+/gi) ?? [];
+  return [...new Set(matched.map((item) => item.toLowerCase()))];
+}
+
+function parseRecencyDays(ruText: string): number {
+  const match = ruText.match(/последн(?:ие|их)\s+(\d+)\s+дн/iu);
+  const parsed = match ? Number.parseInt(match[1], 10) : Number.NaN;
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 14;
+}
+
+function resolveSourceCount(localeRu: Record<string, unknown>): number | null {
+  const excerpt = typeof localeRu.excerpt === "string" ? localeRu.excerpt : "";
+  const match = excerpt.match(/(\d+)\s+актуал/iu);
+  const parsed = match ? Number.parseInt(match[1], 10) : Number.NaN;
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+function normalizeRuLocale(locale: unknown): NormalizeRuLocaleResult {
+  if (!isObjectRecord(locale) || !isObjectRecord(locale.ru)) {
+    return {
+      changed: false,
+      locale,
+    };
+  }
+
+  const currentLocale = locale as Record<string, unknown>;
+  const currentRu = currentLocale.ru as Record<string, unknown>;
+  const baseline = JSON.stringify(currentRu);
+
+  const nextLocale = JSON.parse(JSON.stringify(currentLocale)) as Record<string, unknown>;
+  const nextRu = nextLocale.ru as Record<string, unknown>;
+
+  const titleRu = typeof nextRu.title === "string" ? nextRu.title : "Материал";
+  const sourceCount = resolveSourceCount(currentRu);
+  const recencyDays = parseRecencyDays(collectRuText({ locale: currentLocale }));
+
+  nextRu.excerpt = sourceCount
+    ? `Материал подготовлен на основе ${sourceCount} актуальных источников с обязательной многоэтапной проверкой.`
+    : "Материал подготовлен на основе актуальных источников с обязательной многоэтапной проверкой.";
+  nextRu.seoDescription =
+    "Статья на основе deep research с проверкой релевантности, свежести, разнообразия доменов и подтверждения сигналов.";
+
+  const contentBlocks: Array<Record<string, unknown>> = Array.isArray(nextRu.contentBlocks)
+    ? nextRu.contentBlocks.map((block) => {
+        if (isObjectRecord(block)) {
+          return {
+            ...block,
+            paragraphs: Array.isArray(block.paragraphs)
+              ? block.paragraphs.filter((item): item is string => typeof item === "string")
+              : [],
+            bullets: Array.isArray(block.bullets)
+              ? block.bullets.filter((item): item is string => typeof item === "string")
+              : undefined,
+          };
+        }
+
+        return { heading: "", paragraphs: [] as string[] };
+      })
+    : [];
+
+  const first = isObjectRecord(contentBlocks[0]) ? (contentBlocks[0] as Record<string, unknown>) : {};
+  first.heading = "Область исследования";
+  first.paragraphs = [
+    `Тема материала: ${titleRu}.`,
+    `Источники отобраны за последние ${recencyDays} дней и прошли многоэтапную верификацию.`,
+  ];
+  contentBlocks[0] = first;
+
+  const second = isObjectRecord(contentBlocks[1]) ? (contentBlocks[1] as Record<string, unknown>) : {};
+  second.heading = "Подтверждённые выводы";
+  const secondParagraphs = Array.isArray(second.paragraphs)
+    ? second.paragraphs.filter((item): item is string => typeof item === "string")
+    : [];
+
+  const normalizedSignals = secondParagraphs.map((paragraph, index) => {
+    const sourceIds = extractSourceIds(paragraph);
+    if (sourceIds.length > 0) {
+      return `Сигнал ${index + 1}: подтверждён в независимых источниках (${sourceIds.join(", ")}).`;
+    }
+
+    if (/signal\s+\d+/i.test(paragraph) || /repeated in \d+ independent sources/i.test(paragraph)) {
+      return `Сигнал ${index + 1}: подтверждён в независимых источниках.`;
+    }
+
+    return paragraph;
+  });
+
+  second.paragraphs =
+    normalizedSignals.length > 0
+      ? normalizedSignals
+      : ["Не удалось выделить повторяющиеся подтверждённые сигналы."];
+  contentBlocks[1] = second;
+
+  const third = isObjectRecord(contentBlocks[2]) ? (contentBlocks[2] as Record<string, unknown>) : {};
+  third.heading = "Актуальные источники";
+  third.paragraphs = ["Ниже приведены только свежие и релевантные источники."];
+  contentBlocks[2] = third;
+
+  nextRu.contentBlocks = contentBlocks;
+
+  return {
+    changed: JSON.stringify(nextRu) !== baseline,
+    locale: nextLocale,
+  };
+}
+
+async function runTableBackfill(
+  adminClient: SupabaseClient,
+  options: RunBlogRuBackfillOptions,
+): Promise<BlogRuBackfillTargetStats> {
+  const stats = createEmptyStats(false);
+
+  const { data, error } = await adminClient
+    .from("blog_posts")
+    .select("slug, locale, research")
+    .order("published_at", { ascending: false })
+    .limit(options.limit);
+
+  if (error) {
+    if (isMissingBlogPostsTableError(error.message)) {
+      return createEmptyStats(true);
+    }
+
+    throw new Error(`Failed to read blog_posts: ${error.message}`);
+  }
+
+  const rows = Array.isArray(data) ? (data as BackfillRow[]) : [];
+
+  for (const row of rows) {
+    stats.scanned += 1;
+
+    const post: LegacyPostLike = {
+      slug: row.slug,
+      locale: row.locale,
+      research: row.research,
+    };
+
+    if (!isLegacyAutoPost(post)) {
+      continue;
+    }
+
+    stats.legacy += 1;
+    const normalized = normalizeRuLocale(row.locale);
+    if (!normalized.changed) {
+      continue;
+    }
+
+    stats.changed += 1;
+
+    if (!options.apply) {
+      continue;
+    }
+
+    const { error: updateError } = await adminClient
+      .from("blog_posts")
+      .update({
+        locale: normalized.locale,
+        updated_at: new Date().toISOString(),
+      })
+      .eq("slug", row.slug)
+      .limit(1);
+
+    if (updateError) {
+      stats.errors += 1;
+      continue;
+    }
+
+    stats.applied += 1;
+  }
+
+  return stats;
+}
+
+async function runStorageBackfill(
+  adminClient: SupabaseClient,
+  options: RunBlogRuBackfillOptions,
+): Promise<BlogRuBackfillTargetStats> {
+  const stats = createEmptyStats(false);
+
+  const { data: files, error: listError } = await adminClient.storage
+    .from(BLOG_STORAGE_BUCKET)
+    .list(BLOG_STORAGE_POSTS_PREFIX, {
+      limit: options.limit,
+      sortBy: {
+        column: "name",
+        order: "desc",
+      },
+    });
+
+  if (listError) {
+    return createEmptyStats(true);
+  }
+
+  for (const file of files ?? []) {
+    if (!file?.name || !file.name.endsWith(".json")) {
+      continue;
+    }
+
+    stats.scanned += 1;
+    const objectPath = `${BLOG_STORAGE_POSTS_PREFIX}/${file.name}`;
+
+    try {
+      const { data, error: downloadError } = await adminClient.storage
+        .from(BLOG_STORAGE_BUCKET)
+        .download(objectPath);
+
+      if (downloadError || !data) {
+        stats.errors += 1;
+        continue;
+      }
+
+      const rawText = await data.text();
+      const post = JSON.parse(rawText) as LegacyPostLike;
+
+      if (!isLegacyAutoPost(post)) {
+        continue;
+      }
+
+      stats.legacy += 1;
+      const normalized = normalizeRuLocale(post.locale);
+      if (!normalized.changed) {
+        continue;
+      }
+
+      stats.changed += 1;
+
+      if (!options.apply) {
+        continue;
+      }
+
+      const nextPost = {
+        ...post,
+        locale: normalized.locale,
+        updatedAt: new Date().toISOString(),
+      };
+
+      const { error: uploadError } = await adminClient.storage
+        .from(BLOG_STORAGE_BUCKET)
+        .upload(objectPath, JSON.stringify(nextPost, null, 2), {
+          contentType: "application/json; charset=utf-8",
+          upsert: true,
+        });
+
+      if (uploadError) {
+        stats.errors += 1;
+        continue;
+      }
+
+      stats.applied += 1;
+    } catch {
+      stats.errors += 1;
+    }
+  }
+
+  return stats;
+}
+
+export async function runBlogRuBackfill(options: RunBlogRuBackfillOptions): Promise<BlogRuBackfillResult> {
+  const adminClient = createSupabaseAdminClient();
+
+  if (!adminClient) {
+    throw new Error(
+      "Supabase admin configuration is missing. Set NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY.",
+    );
+  }
+
+  const limit = clampLimit(options.limit);
+  const normalizedOptions: RunBlogRuBackfillOptions = {
+    ...options,
+    limit,
+  };
+
+  const table = await runTableBackfill(adminClient, normalizedOptions);
+  const storage = await runStorageBackfill(adminClient, normalizedOptions);
+
+  return {
+    table,
+    storage,
+    changed: table.changed + storage.changed,
+    applied: table.applied + storage.applied,
+    errors: table.errors + storage.errors,
+  };
+}
+
+export async function persistBlogRuBackfillRun(
+  input: BlogRuBackfillRunPersistInput,
+): Promise<BlogRuBackfillRunPersistResult> {
+  const adminClient = createSupabaseAdminClient();
+
+  if (!adminClient) {
+    return { recorded: false };
+  }
+
+  const status = input.status ?? toBackfillRunStatus(input.result, input.errorMessage);
+  const limit = clampLimit(input.limit);
+  const runPayload = {
+    status,
+    apply: input.apply,
+    scan_limit: limit,
+    table_stats: input.result.table,
+    storage_stats: input.result.storage,
+    changed_total: input.result.changed,
+    applied_total: input.result.applied,
+    error_total: input.result.errors,
+    error_message: input.errorMessage ?? null,
+  };
+
+  const { data, error } = await adminClient
+    .from(BACKFILL_RUNS_TABLE)
+    .insert(runPayload)
+    .select("id")
+    .single();
+
+  if (error) {
+    if (shouldSkipBackfillRunsTable(error)) {
+      return { recorded: false };
+    }
+
+    throw new Error(`Failed to persist backfill run: ${error.message}`);
+  }
+
+  const runId = isObjectRecord(data) && typeof data.id === "string" ? data.id : undefined;
+  return {
+    recorded: true,
+    runId,
+  };
+}
+
+export async function getRecentBlogRuBackfillRuns(limit = 8): Promise<BlogRuBackfillRunHistory> {
+  const adminClient = createSupabaseAdminClient();
+
+  if (!adminClient) {
+    return {
+      available: false,
+      runs: [],
+    };
+  }
+
+  const safeLimit = Math.max(1, Math.min(limit, 50));
+  const { data, error } = await adminClient
+    .from(BACKFILL_RUNS_TABLE)
+    .select(
+      "id, created_at, status, apply, scan_limit, table_stats, storage_stats, changed_total, applied_total, error_total, error_message",
+    )
+    .order("created_at", { ascending: false })
+    .limit(safeLimit);
+
+  if (error) {
+    if (shouldSkipBackfillRunsTable(error)) {
+      return {
+        available: false,
+        runs: [],
+      };
+    }
+
+    throw new Error(`Failed to read backfill history: ${error.message}`);
+  }
+
+  const runs = Array.isArray(data)
+    ? data
+        .map((row) => toBackfillRunRecord(isObjectRecord(row) ? row : {}))
+        .filter((row): row is BlogRuBackfillRunRecord => Boolean(row))
+    : [];
+
+  return {
+    available: true,
+    runs,
+  };
+}

--- a/scripts/blog-backfill-ru.mjs
+++ b/scripts/blog-backfill-ru.mjs
@@ -1,0 +1,484 @@
+#!/usr/bin/env node
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { createClient } from "@supabase/supabase-js";
+
+const BLOG_STORAGE_BUCKET = "blog-automation";
+const BLOG_STORAGE_POSTS_PREFIX = "posts";
+const BLOG_DISK_POSTS_ROOT = path.join(process.cwd(), "content", "blog", "posts");
+
+function parseArgs(argv) {
+  const flags = new Set(argv);
+  const limitArg = argv.find((arg) => arg.startsWith("--limit="));
+  const parsedLimit = limitArg ? Number.parseInt(limitArg.split("=")[1] ?? "", 10) : 1000;
+  const limit = Number.isFinite(parsedLimit) && parsedLimit > 0 ? Math.min(parsedLimit, 5000) : 1000;
+
+  return {
+    apply: flags.has("--apply"),
+    limit,
+  };
+}
+
+function getEnv(name) {
+  const value = process.env[name];
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function createSupabaseAdminClientOrNull() {
+  const supabaseUrl = getEnv("NEXT_PUBLIC_SUPABASE_URL") || getEnv("SUPABASE_URL");
+  const serviceRoleKey = getEnv("SUPABASE_SERVICE_ROLE_KEY");
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    return null;
+  }
+
+  return createClient(supabaseUrl, serviceRoleKey, {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+    },
+  });
+}
+
+function isMissingTableError(message) {
+  return (
+    message.includes("Could not find the table 'public.blog_posts'") ||
+    message.includes('relation "blog_posts" does not exist')
+  );
+}
+
+function collectRuText(post) {
+  const ru = post?.locale?.ru;
+  if (!ru) {
+    return "";
+  }
+
+  const paragraphs = Array.isArray(ru.contentBlocks)
+    ? ru.contentBlocks.flatMap((block) => {
+        const heading = typeof block?.heading === "string" ? block.heading : "";
+        const paras = Array.isArray(block?.paragraphs)
+          ? block.paragraphs.filter((item) => typeof item === "string")
+          : [];
+        return [heading, ...paras];
+      })
+    : [];
+
+  return [ru.excerpt, ru.seoDescription, ...paragraphs].filter(Boolean).join("\n");
+}
+
+function isLegacyAutoPost(post) {
+  const provider = post?.research?.provider;
+  if (provider !== "exa-search-deep") {
+    return false;
+  }
+
+  const ruText = collectRuText(post);
+  if (!ruText) {
+    return false;
+  }
+
+  return /(по теме:|signal\s+\d+|supporting sources|repeated in \d+ independent sources|тема:\s|deep research по теме|подтверждающие источники)/i.test(
+    ruText,
+  );
+}
+
+function extractSourceIds(value) {
+  if (typeof value !== "string") {
+    return [];
+  }
+
+  const matched = value.match(/src-\d+/gi) ?? [];
+  return [...new Set(matched.map((item) => item.toLowerCase()))];
+}
+
+function readRecencyDays(post) {
+  const ruText = collectRuText(post);
+  const match = ruText.match(/последн(?:ие|их)\s+(\d+)\s+дн/iu);
+  const parsed = match ? Number.parseInt(match[1], 10) : Number.NaN;
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 14;
+}
+
+function resolveSourceCount(post) {
+  const explicit = post?.research?.sourceCount;
+  if (Number.isFinite(explicit) && explicit > 0) {
+    return Math.round(explicit);
+  }
+
+  const ruExcerpt = post?.locale?.ru?.excerpt;
+  const match = typeof ruExcerpt === "string" ? ruExcerpt.match(/(\d+)\s+актуал/iu) : null;
+  const parsed = match ? Number.parseInt(match[1], 10) : Number.NaN;
+
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+function normalizeRuCopy(post) {
+  const ru = post?.locale?.ru;
+  if (!ru || typeof ru !== "object") {
+    return {
+      changed: false,
+      locale: post.locale,
+    };
+  }
+
+  const locale = {
+    ...post.locale,
+    ru: {
+      ...ru,
+      contentBlocks: Array.isArray(ru.contentBlocks)
+        ? ru.contentBlocks.map((block) => ({
+            ...block,
+            paragraphs: Array.isArray(block?.paragraphs)
+              ? block.paragraphs.filter((item) => typeof item === "string")
+              : [],
+            bullets: Array.isArray(block?.bullets)
+              ? block.bullets.filter((item) => typeof item === "string")
+              : undefined,
+          }))
+        : [],
+    },
+  };
+
+  const nextRu = locale.ru;
+  const oldRuSnapshot = JSON.stringify(ru);
+
+  const sourceCount = resolveSourceCount(post);
+  nextRu.excerpt = sourceCount
+    ? `Материал подготовлен на основе ${sourceCount} актуальных источников с обязательной многоэтапной проверкой.`
+    : "Материал подготовлен на основе актуальных источников с обязательной многоэтапной проверкой.";
+  nextRu.seoDescription =
+    "Статья на основе deep research с проверкой релевантности, свежести, разнообразия доменов и подтверждения сигналов.";
+
+  const recencyDays = readRecencyDays(post);
+  const first = nextRu.contentBlocks[0] ?? { heading: "", paragraphs: [] };
+  first.heading = "Область исследования";
+  first.paragraphs = [
+    `Тема материала: ${nextRu.title}.`,
+    `Источники отобраны за последние ${recencyDays} дней и прошли многоэтапную верификацию.`,
+  ];
+  nextRu.contentBlocks[0] = first;
+
+  const second = nextRu.contentBlocks[1] ?? { heading: "", paragraphs: [] };
+  second.heading = "Подтверждённые выводы";
+  const sourceParagraphs = Array.isArray(second.paragraphs) ? second.paragraphs : [];
+  const rewritten = sourceParagraphs.map((paragraph, index) => {
+    const ids = extractSourceIds(paragraph);
+    if (ids.length === 0) {
+      if (/signal\s+\d+/i.test(paragraph) || /repeated in \d+ independent sources/i.test(paragraph)) {
+        return `Сигнал ${index + 1}: подтверждён в независимых источниках.`;
+      }
+
+      return paragraph;
+    }
+
+    return `Сигнал ${index + 1}: подтверждён в независимых источниках (${ids.join(", ")}).`;
+  });
+  second.paragraphs =
+    rewritten.length > 0
+      ? rewritten
+      : ["Не удалось выделить повторяющиеся подтверждённые сигналы."];
+  nextRu.contentBlocks[1] = second;
+
+  const third = nextRu.contentBlocks[2] ?? { heading: "", paragraphs: [] };
+  third.heading = "Актуальные источники";
+  third.paragraphs = ["Ниже приведены только свежие и релевантные источники."];
+  nextRu.contentBlocks[2] = third;
+
+  const changed = JSON.stringify(nextRu) !== oldRuSnapshot;
+
+  return {
+    changed,
+    locale,
+  };
+}
+
+async function backfillBlogPostsTable(client, options) {
+  const stats = {
+    scanned: 0,
+    legacy: 0,
+    changed: 0,
+    applied: 0,
+    errors: 0,
+    skipped: false,
+  };
+
+  const { data, error } = await client
+    .from("blog_posts")
+    .select("slug, locale, research")
+    .order("published_at", { ascending: false })
+    .limit(options.limit);
+
+  if (error) {
+    if (isMissingTableError(error.message)) {
+      stats.skipped = true;
+      return stats;
+    }
+
+    throw new Error(`Failed to read blog_posts: ${error.message}`);
+  }
+
+  const rows = Array.isArray(data) ? data : [];
+
+  for (const row of rows) {
+    stats.scanned += 1;
+
+    const post = {
+      slug: row.slug,
+      locale: row.locale,
+      research: row.research,
+    };
+
+    if (!isLegacyAutoPost(post)) {
+      continue;
+    }
+
+    stats.legacy += 1;
+    const normalized = normalizeRuCopy(post);
+    if (!normalized.changed) {
+      continue;
+    }
+
+    stats.changed += 1;
+
+    if (!options.apply) {
+      continue;
+    }
+
+    const { error: updateError } = await client
+      .from("blog_posts")
+      .update({
+        locale: normalized.locale,
+        updated_at: new Date().toISOString(),
+      })
+      .eq("slug", row.slug)
+      .limit(1);
+
+    if (updateError) {
+      stats.errors += 1;
+      continue;
+    }
+
+    stats.applied += 1;
+  }
+
+  return stats;
+}
+
+async function backfillBlogPostsStorage(client, options) {
+  const stats = {
+    scanned: 0,
+    legacy: 0,
+    changed: 0,
+    applied: 0,
+    errors: 0,
+  };
+
+  const { data: files, error: listError } = await client.storage
+    .from(BLOG_STORAGE_BUCKET)
+    .list(BLOG_STORAGE_POSTS_PREFIX, {
+      limit: options.limit,
+      sortBy: {
+        column: "name",
+        order: "desc",
+      },
+    });
+
+  if (listError) {
+    throw new Error(`Failed to list Supabase Storage posts: ${listError.message}`);
+  }
+
+  for (const file of files ?? []) {
+    if (!file?.name || !file.name.endsWith(".json")) {
+      continue;
+    }
+
+    stats.scanned += 1;
+    const objectPath = `${BLOG_STORAGE_POSTS_PREFIX}/${file.name}`;
+
+    try {
+      const { data, error: downloadError } = await client.storage
+        .from(BLOG_STORAGE_BUCKET)
+        .download(objectPath);
+
+      if (downloadError || !data) {
+        stats.errors += 1;
+        continue;
+      }
+
+      const rawText = await data.text();
+      const post = JSON.parse(rawText);
+
+      if (!isLegacyAutoPost(post)) {
+        continue;
+      }
+
+      stats.legacy += 1;
+      const normalized = normalizeRuCopy(post);
+      if (!normalized.changed) {
+        continue;
+      }
+
+      stats.changed += 1;
+
+      if (!options.apply) {
+        continue;
+      }
+
+      const nextPost = {
+        ...post,
+        locale: normalized.locale,
+        updatedAt: new Date().toISOString(),
+      };
+
+      const { error: uploadError } = await client.storage
+        .from(BLOG_STORAGE_BUCKET)
+        .upload(objectPath, JSON.stringify(nextPost, null, 2), {
+          contentType: "application/json; charset=utf-8",
+          upsert: true,
+        });
+
+      if (uploadError) {
+        stats.errors += 1;
+        continue;
+      }
+
+      stats.applied += 1;
+    } catch {
+      stats.errors += 1;
+    }
+  }
+
+  return stats;
+}
+
+async function backfillBlogPostsDisk(options) {
+  const stats = {
+    scanned: 0,
+    legacy: 0,
+    changed: 0,
+    applied: 0,
+    errors: 0,
+    skipped: false,
+  };
+
+  try {
+    const files = await fs.readdir(BLOG_DISK_POSTS_ROOT, { withFileTypes: true });
+    const jsonFiles = files
+      .filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
+      .slice(0, options.limit);
+
+    for (const file of jsonFiles) {
+      stats.scanned += 1;
+      const filePath = path.join(BLOG_DISK_POSTS_ROOT, file.name);
+
+      try {
+        const raw = await fs.readFile(filePath, "utf8");
+        const post = JSON.parse(raw);
+
+        if (!isLegacyAutoPost(post)) {
+          continue;
+        }
+
+        stats.legacy += 1;
+        const normalized = normalizeRuCopy(post);
+        if (!normalized.changed) {
+          continue;
+        }
+
+        stats.changed += 1;
+
+        if (!options.apply) {
+          continue;
+        }
+
+        const nextPost = {
+          ...post,
+          locale: normalized.locale,
+          updatedAt: new Date().toISOString(),
+        };
+
+        await fs.writeFile(filePath, `${JSON.stringify(nextPost, null, 2)}\n`, "utf8");
+        stats.applied += 1;
+      } catch {
+        stats.errors += 1;
+      }
+    }
+  } catch {
+    stats.skipped = true;
+  }
+
+  return stats;
+}
+
+function printStats(label, stats) {
+  const base = [
+    `[${label}] scanned=${stats.scanned}`,
+    `legacy=${stats.legacy}`,
+    `changed=${stats.changed}`,
+    `applied=${stats.applied}`,
+    `errors=${stats.errors}`,
+  ];
+  if (Object.prototype.hasOwnProperty.call(stats, "skipped")) {
+    base.push(`skipped=${stats.skipped ? "yes" : "no"}`);
+  }
+
+  console.log(base.join(" "));
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const client = createSupabaseAdminClientOrNull();
+
+  console.log(
+    options.apply
+      ? "Running RU copy backfill in APPLY mode."
+      : "Running RU copy backfill in DRY-RUN mode (add --apply to write changes).",
+  );
+
+  const tableStats = {
+    scanned: 0,
+    legacy: 0,
+    changed: 0,
+    applied: 0,
+    errors: 0,
+    skipped: true,
+  };
+  const storageStats = {
+    scanned: 0,
+    legacy: 0,
+    changed: 0,
+    applied: 0,
+    errors: 0,
+    skipped: true,
+  };
+
+  if (client) {
+    Object.assign(tableStats, await backfillBlogPostsTable(client, options));
+    Object.assign(storageStats, await backfillBlogPostsStorage(client, options));
+  } else {
+    console.log(
+      "Supabase admin env is missing. Skipping remote table/storage backfill and continuing with disk posts only.",
+    );
+  }
+
+  const diskStats = await backfillBlogPostsDisk(options);
+
+  printStats("blog_posts", tableStats);
+  printStats("storage", storageStats);
+  printStats("disk", diskStats);
+
+  const changed = tableStats.changed + storageStats.changed + diskStats.changed;
+  const applied = tableStats.applied + storageStats.applied + diskStats.applied;
+  const errors = tableStats.errors + storageStats.errors + diskStats.errors;
+
+  console.log(`Summary: changed=${changed}, applied=${applied}, errors=${errors}`);
+
+  if (errors > 0) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/supabase/migrations/20260210202000_blog_backfill_runs_audit.sql
+++ b/supabase/migrations/20260210202000_blog_backfill_runs_audit.sql
@@ -1,0 +1,30 @@
+-- Audit history for admin-triggered RU blog backfill runs.
+
+create extension if not exists pgcrypto;
+
+create table if not exists public.blog_backfill_runs (
+  id uuid primary key default gen_random_uuid(),
+  created_at timestamptz not null default now(),
+  status text not null check (status in ('success', 'partial', 'failed')),
+  apply boolean not null default true,
+  scan_limit integer not null check (scan_limit >= 1 and scan_limit <= 5000),
+  table_stats jsonb not null default '{}'::jsonb,
+  storage_stats jsonb not null default '{}'::jsonb,
+  changed_total integer not null default 0 check (changed_total >= 0),
+  applied_total integer not null default 0 check (applied_total >= 0),
+  error_total integer not null default 0 check (error_total >= 0),
+  error_message text
+);
+
+create index if not exists blog_backfill_runs_created_at_idx
+  on public.blog_backfill_runs(created_at desc);
+
+alter table public.blog_backfill_runs enable row level security;
+
+drop policy if exists "blog_backfill_runs_service_role_all" on public.blog_backfill_runs;
+create policy "blog_backfill_runs_service_role_all"
+on public.blog_backfill_runs
+for all
+to service_role
+using (true)
+with check (true);


### PR DESCRIPTION
## Summary\n- add RU backfill service for legacy deep-research auto-post normalization (table + storage)\n- add admin action/UI controls to run backfill and display recent run history\n- add Supabase migration for log_backfill_runs audit table\n- add CLI script log:backfill:ru (dry-run + apply modes)\n- document backfill workflow in docs/blog-automation.md\n\n## Verification\n- npm run lint ✅\n- npm run build ✅\n- npm run blog:backfill:ru -- --limit=5 (dry-run) ✅\n\n## Notes\n- This PR is isolated from other branch work and contains only backfill-audit changes.