### PR TITLE
feat(redesign): apply homepage visual system across site pages

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -18,6 +18,7 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { PageFrame } from "@/components/page-templates";
 import { tr } from "@/lib/i18n";
 import { getLocale } from "@/lib/i18n-server";
 import { cn } from "@/lib/utils";
@@ -229,7 +230,7 @@ export default async function AboutPage() {
   const locale = await getLocale();
 
   return (
-    <div className="relative overflow-hidden border-t border-white/10">
+    <PageFrame variant="marketing" className="relative">
       <div className="pointer-events-none absolute inset-0 -z-10 bg-[linear-gradient(180deg,#02070f_0%,#030b16_45%,#050814_100%)]" />
       <div className="about-hero-glow pointer-events-none absolute inset-x-0 top-0 -z-10 h-[760px] bg-[radial-gradient(circle_at_18%_8%,rgba(56,189,248,0.26),transparent_44%),radial-gradient(circle_at_82%_3%,rgba(14,165,233,0.18),transparent_40%)]" />
       <div className="pointer-events-none absolute inset-0 -z-10 bg-[linear-gradient(90deg,rgba(56,189,248,0.06)_1px,transparent_1px),linear-gradient(rgba(56,189,248,0.05)_1px,transparent_1px)] bg-[size:44px_44px] opacity-35" />
@@ -587,6 +588,6 @@ export default async function AboutPage() {
           </div>
         </div>
       </section>
-    </div>
+    </PageFrame>
   );
 }

--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -14,6 +14,7 @@ import {
 
 import { AccountProfileForms } from "@/components/account-profile-forms";
 import { AccountSignOutButton } from "@/components/account-sign-out-button";
+import { PageFrame } from "@/components/page-templates";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -205,10 +206,9 @@ export default async function AccountPage() {
   const isEmailVerified = Boolean(userData.user.email_confirmed_at);
 
   return (
-    <div className="relative overflow-hidden border-t border-white/10">
-      <div className="pointer-events-none absolute inset-0 -z-10 bg-[linear-gradient(180deg,#060a14_0%,#070c18_48%,#050913_100%)]" />
+    <PageFrame variant="ops">
       <div className="mx-auto w-full max-w-6xl px-4 py-10 sm:px-6">
-      <section className="rounded-2xl border border-white/10 bg-slate-900/72 p-6">
+        <section className="rounded-2xl border border-white/10 bg-slate-900/72 p-6">
         <div className="flex flex-col gap-5 lg:flex-row lg:items-center lg:justify-between">
           <div className="flex items-center gap-4">
             {avatarUrl ? (
@@ -445,6 +445,6 @@ export default async function AccountPage() {
         </Card>
       </div>
       </div>
-    </div>
+    </PageFrame>
   );
 }

--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -205,7 +205,9 @@ export default async function AccountPage() {
   const isEmailVerified = Boolean(userData.user.email_confirmed_at);
 
   return (
-    <div className="mx-auto w-full max-w-6xl px-4 py-10 sm:px-6">
+    <div className="relative overflow-hidden border-t border-white/10">
+      <div className="pointer-events-none absolute inset-0 -z-10 bg-[linear-gradient(180deg,#060a14_0%,#070c18_48%,#050913_100%)]" />
+      <div className="mx-auto w-full max-w-6xl px-4 py-10 sm:px-6">
       <section className="rounded-2xl border border-white/10 bg-slate-900/72 p-6">
         <div className="flex flex-col gap-5 lg:flex-row lg:items-center lg:justify-between">
           <div className="flex items-center gap-4">
@@ -441,6 +443,7 @@ export default async function AccountPage() {
             })}
           </CardContent>
         </Card>
+      </div>
       </div>
     </div>
   );

--- a/app/admin/blog/page.tsx
+++ b/app/admin/blog/page.tsx
@@ -6,6 +6,7 @@ import {
   createBlogPostFromDeepResearchAction,
   logoutAdminAction,
 } from "@/app/admin/actions";
+import { PageFrame } from "@/components/page-templates";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -57,7 +58,8 @@ export default async function AdminBlogPage({ searchParams }: AdminBlogPageProps
   const errorMessage = error ? tr(locale, formatError(error) ?? error, formatError(error) ?? error) : null;
 
   return (
-    <div className="mx-auto w-full max-w-6xl px-4 py-10 sm:px-6">
+    <PageFrame variant="ops">
+      <div className="mx-auto w-full max-w-6xl px-4 py-10 sm:px-6">
       <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
         <div>
           <h1 className="text-2xl font-semibold text-slate-100">
@@ -108,7 +110,7 @@ export default async function AdminBlogPage({ searchParams }: AdminBlogPageProps
         </div>
       ) : null}
 
-      <div className="grid gap-4 lg:grid-cols-[2fr_1fr]">
+      <div className="mt-6 grid gap-4 lg:grid-cols-[2fr_1fr]">
         <Card className="border-white/10 bg-slate-900/70">
           <CardHeader>
             <CardTitle className="text-slate-100">
@@ -272,6 +274,7 @@ export default async function AdminBlogPage({ searchParams }: AdminBlogPageProps
           </CardContent>
         </Card>
       </div>
-    </div>
+      </div>
+    </PageFrame>
   );
 }

--- a/app/admin/login/page.tsx
+++ b/app/admin/login/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 
 import { loginAdminAction } from "@/app/admin/actions";
+import { PageFrame, PageHero, PageSection } from "@/components/page-templates";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -42,57 +43,69 @@ export default async function AdminLoginPage({ searchParams }: AdminLoginPagePro
       : null;
 
   return (
-    <div className="mx-auto flex min-h-[70vh] w-full max-w-md flex-col justify-center px-4 py-12">
-      <div className="rounded-2xl border border-white/10 bg-slate-900/70 p-6">
-        <h1 className="text-xl font-semibold text-slate-100">
-          {tr(locale, "Admin access", "Доступ администратора")}
-        </h1>
-        <p className="mt-2 text-sm text-slate-300">
-          {tr(locale, "Enter admin token to open moderation dashboard.", "Введите админ-токен, чтобы открыть панель модерации.")}
-        </p>
-
-        {errorMessage ? (
-          <p className="mt-3 rounded-md border border-rose-400/30 bg-rose-500/10 px-3 py-2 text-sm text-rose-200">
-            {errorMessage}
+    <PageFrame variant="ops">
+      <div className="mx-auto flex w-full max-w-4xl flex-col gap-6 px-4 py-10 sm:px-6 sm:py-14">
+        <PageHero
+          badgeTone="emerald"
+          eyebrow={tr(locale, "Operations", "Операции")}
+          title={tr(locale, "Admin access", "Доступ администратора")}
+          description={tr(
+            locale,
+            "Use a privileged token to enter the moderation dashboard and manage pending submissions.",
+            "Используйте привилегированный токен для входа в панель модерации и управления ожидающими заявками.",
+          )}
+        />
+        <PageSection className="mx-auto w-full max-w-md">
+          <h2 className="text-xl font-semibold text-slate-100">
+            {tr(locale, "Token sign-in", "Вход по токену")}
+          </h2>
+          <p className="mt-2 text-sm text-slate-300">
+            {tr(locale, "Enter admin token to open moderation dashboard.", "Введите админ-токен, чтобы открыть панель модерации.")}
           </p>
-        ) : null}
 
-        {devHint ? (
-          <p className="mt-3 rounded-md border border-amber-400/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
-            {devHint}
-          </p>
-        ) : null}
+          {errorMessage ? (
+            <p className="mt-3 rounded-md border border-rose-400/30 bg-rose-500/10 px-3 py-2 text-sm text-rose-200">
+              {errorMessage}
+            </p>
+          ) : null}
 
-        <form action={loginAdminAction} className="mt-5 space-y-3">
-          <input type="hidden" name="redirect" value={redirect || "/admin"} />
-          <input
-            type="text"
-            name="username"
-            autoComplete="username"
-            defaultValue="admin"
-            tabIndex={-1}
-            readOnly
-            aria-hidden="true"
-            className="sr-only"
-          />
+          {devHint ? (
+            <p className="mt-3 rounded-md border border-amber-400/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
+              {devHint}
+            </p>
+          ) : null}
 
-          <div className="space-y-1.5">
-            <Label htmlFor="token">{tr(locale, "Admin token", "Токен администратора")}</Label>
-            <Input
-              id="token"
-              name="token"
-              type="password"
-              autoComplete="current-password"
-              required
-              className="border-white/10 bg-slate-950/80"
+          <form action={loginAdminAction} className="mt-5 space-y-3">
+            <input type="hidden" name="redirect" value={redirect || "/admin"} />
+            <input
+              type="text"
+              name="username"
+              autoComplete="username"
+              defaultValue="admin"
+              tabIndex={-1}
+              readOnly
+              aria-hidden="true"
+              className="sr-only"
             />
-          </div>
 
-          <Button type="submit" className="w-full bg-blue-500 hover:bg-blue-400">
-            {tr(locale, "Sign in", "Войти")}
-          </Button>
-        </form>
+            <div className="space-y-1.5">
+              <Label htmlFor="token">{tr(locale, "Admin token", "Токен администратора")}</Label>
+              <Input
+                id="token"
+                name="token"
+                type="password"
+                autoComplete="current-password"
+                required
+                className="border-white/10 bg-slate-950/80"
+              />
+            </div>
+
+            <Button type="submit" className="w-full bg-blue-500 hover:bg-blue-400">
+              {tr(locale, "Sign in", "Войти")}
+            </Button>
+          </form>
+        </PageSection>
       </div>
-    </div>
+    </PageFrame>
   );
 }

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { FileText } from "lucide-react";
 
 import { logoutAdminAction, moderateServerStatusAction } from "@/app/admin/actions";
+import { PageFrame, PageHero, PageMetric, PageSection } from "@/components/page-templates";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -61,119 +62,130 @@ function getFeedbackMessage({
 export default async function AdminPage({ searchParams }: AdminPageProps) {
   const locale = await getLocale();
   const pendingServers = await getPendingServers();
+  const pendingCount = pendingServers.length;
   const { success, error } = await searchParams;
   const feedback = getFeedbackMessage({ locale, success, error });
 
   return (
-    <div className="mx-auto w-full max-w-6xl px-4 py-10 sm:px-6">
-      <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
-        <div>
-          <h1 className="text-2xl font-semibold text-slate-100">{tr(locale, "Moderation", "Модерация")}</h1>
-          <p className="text-sm text-slate-300">
-            {tr(
-              locale,
-              "Review pending MCP server submissions and decide approval status.",
-              "Проверьте ожидающие заявки MCP-серверов и примите решение о статусе.",
-            )}
-          </p>
-        </div>
+    <PageFrame variant="ops">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 py-10 sm:px-6 sm:py-14">
+        <PageHero
+          badgeTone="emerald"
+          eyebrow={tr(locale, "Operations", "Операции")}
+          title={tr(locale, "Moderation Dashboard", "Панель модерации")}
+          description={tr(
+            locale,
+            "Review pending MCP submissions, approve trusted listings, and keep catalog quality high.",
+            "Проверяйте ожидающие заявки MCP, одобряйте надежные листинги и поддерживайте качество каталога.",
+          )}
+          actions={
+            <div className="flex flex-wrap items-center gap-2">
+              <Button
+                asChild
+                variant="outline"
+                className="border-white/15 bg-white/[0.02] hover:bg-white/[0.06]"
+              >
+                <Link href="/admin/blog">
+                  <FileText className="size-4" />
+                  {tr(locale, "Blog studio", "Студия блога")}
+                </Link>
+              </Button>
 
-        <div className="flex flex-wrap items-center gap-2">
-          <Button
-            asChild
-            variant="outline"
-            className="border-white/15 bg-white/[0.02] hover:bg-white/[0.06]"
+              <form action={logoutAdminAction}>
+                <Button
+                  type="submit"
+                  variant="outline"
+                  className="border-white/15 bg-white/[0.02] hover:bg-white/[0.06]"
+                >
+                  {tr(locale, "Logout", "Выйти")}
+                </Button>
+              </form>
+            </div>
+          }
+          metrics={
+            <PageMetric
+              label={tr(locale, "Pending queue", "Очередь на модерацию")}
+              value={pendingCount}
+              valueClassName={pendingCount > 0 ? "text-amber-200" : "text-emerald-200"}
+            />
+          }
+        />
+
+        {feedback ? (
+          <div
+            className={`rounded-md border px-3 py-2 text-sm ${
+              feedback.tone === "success"
+                ? "border-emerald-400/35 bg-emerald-500/10 text-emerald-200"
+                : "border-rose-400/35 bg-rose-500/10 text-rose-200"
+            }`}
           >
-            <Link href="/admin/blog">
-              <FileText className="size-4" />
-              {tr(locale, "Blog studio", "Студия блога")}
-            </Link>
-          </Button>
+            {feedback.text}
+          </div>
+        ) : null}
 
-          <form action={logoutAdminAction}>
-            <Button
-              type="submit"
-              variant="outline"
-              className="border-white/15 bg-white/[0.02] hover:bg-white/[0.06]"
-            >
-              {tr(locale, "Logout", "Выйти")}
-            </Button>
-          </form>
-        </div>
-      </div>
-
-      {feedback ? (
-        <div
-          className={`mb-4 rounded-md border px-3 py-2 text-sm ${
-            feedback.tone === "success"
-              ? "border-emerald-400/35 bg-emerald-500/10 text-emerald-200"
-              : "border-rose-400/35 bg-rose-500/10 text-rose-200"
-          }`}
-        >
-          {feedback.text}
-        </div>
-      ) : null}
-
-      {pendingServers.length === 0 ? (
-        <Card className="border-white/10 bg-slate-900/55">
-          <CardHeader>
-            <CardTitle className="text-slate-100">{tr(locale, "No pending submissions", "Нет ожидающих заявок")}</CardTitle>
-          </CardHeader>
-          <CardContent className="text-sm text-slate-300">
-            {tr(
-              locale,
-              "New servers submitted through the public form will appear here.",
-              "Новые серверы, отправленные через публичную форму, появятся здесь.",
-            )}
-          </CardContent>
-        </Card>
-      ) : (
-        <div className="grid gap-4 lg:grid-cols-2">
-          {pendingServers.map((mcpServer) => (
-            <Card key={mcpServer.id} className="border-white/10 bg-slate-900/70">
-              <CardHeader className="space-y-2">
-                <CardTitle className="text-base text-slate-100">{mcpServer.name}</CardTitle>
-                <div className="flex flex-wrap gap-2">
-                  <Badge className="bg-blue-500/15 text-blue-300">{mcpServer.category}</Badge>
-                  <Badge variant="secondary" className="bg-white/8 text-slate-300">
-                    {mcpServer.authType}
-                  </Badge>
-                </div>
+        <PageSection>
+          {pendingServers.length === 0 ? (
+            <Card className="border-white/10 bg-slate-900/55">
+              <CardHeader>
+                <CardTitle className="text-slate-100">{tr(locale, "No pending submissions", "Нет ожидающих заявок")}</CardTitle>
               </CardHeader>
-
-              <CardContent className="space-y-4">
-                <p className="text-sm text-slate-300">{mcpServer.description}</p>
-                <p className="truncate text-xs text-slate-400">{mcpServer.serverUrl}</p>
-
-                <div className="flex gap-2">
-                  <form action={moderateServerStatusAction} className="w-full">
-                    <input type="hidden" name="serverId" value={mcpServer.id} />
-                    <input type="hidden" name="status" value="active" />
-                    <Button
-                      type="submit"
-                      className="w-full bg-emerald-500/80 text-white hover:bg-emerald-400"
-                    >
-                      {tr(locale, "Approve", "Одобрить")}
-                    </Button>
-                  </form>
-
-                  <form action={moderateServerStatusAction} className="w-full">
-                    <input type="hidden" name="serverId" value={mcpServer.id} />
-                    <input type="hidden" name="status" value="rejected" />
-                    <Button
-                      type="submit"
-                      variant="outline"
-                      className="w-full border-rose-400/40 bg-rose-500/10 text-rose-200 hover:bg-rose-500/20"
-                    >
-                      {tr(locale, "Reject", "Отклонить")}
-                    </Button>
-                  </form>
-                </div>
+              <CardContent className="text-sm text-slate-300">
+                {tr(
+                  locale,
+                  "New servers submitted through the public form will appear here.",
+                  "Новые серверы, отправленные через публичную форму, появятся здесь.",
+                )}
               </CardContent>
             </Card>
-          ))}
-        </div>
-      )}
-    </div>
+          ) : (
+            <div className="grid gap-4 lg:grid-cols-2">
+              {pendingServers.map((mcpServer) => (
+                <Card key={mcpServer.id} className="border-white/10 bg-slate-900/70">
+                  <CardHeader className="space-y-2">
+                    <CardTitle className="text-base text-slate-100">{mcpServer.name}</CardTitle>
+                    <div className="flex flex-wrap gap-2">
+                      <Badge className="bg-blue-500/15 text-blue-300">{mcpServer.category}</Badge>
+                      <Badge variant="secondary" className="bg-white/8 text-slate-300">
+                        {mcpServer.authType}
+                      </Badge>
+                    </div>
+                  </CardHeader>
+
+                  <CardContent className="space-y-4">
+                    <p className="text-sm text-slate-300">{mcpServer.description}</p>
+                    <p className="truncate text-xs text-slate-400">{mcpServer.serverUrl}</p>
+
+                    <div className="flex gap-2">
+                      <form action={moderateServerStatusAction} className="w-full">
+                        <input type="hidden" name="serverId" value={mcpServer.id} />
+                        <input type="hidden" name="status" value="active" />
+                        <Button
+                          type="submit"
+                          className="w-full bg-emerald-500/80 text-white hover:bg-emerald-400"
+                        >
+                          {tr(locale, "Approve", "Одобрить")}
+                        </Button>
+                      </form>
+
+                      <form action={moderateServerStatusAction} className="w-full">
+                        <input type="hidden" name="serverId" value={mcpServer.id} />
+                        <input type="hidden" name="status" value="rejected" />
+                        <Button
+                          type="submit"
+                          variant="outline"
+                          className="w-full border-rose-400/40 bg-rose-500/10 text-rose-200 hover:bg-rose-500/20"
+                        >
+                          {tr(locale, "Reject", "Отклонить")}
+                        </Button>
+                      </form>
+                    </div>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          )}
+        </PageSection>
+      </div>
+    </PageFrame>
   );
 }

--- a/app/auth/check-email/page.tsx
+++ b/app/auth/check-email/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 
+import { PageFrame, PageHero } from "@/components/page-templates";
 import { AuthCheckEmailPanel } from "@/components/auth-check-email-panel";
 import { normalizeInternalPath, type AuthCheckEmailFlow } from "@/lib/auth-redirects";
 import { tr } from "@/lib/i18n";
@@ -31,14 +32,29 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function AuthCheckEmailPage({ searchParams }: AuthCheckEmailPageProps) {
+  const locale = await getLocale();
   const { flow, email, next } = await searchParams;
   const parsedFlow = parseFlow(flow);
   const safeNextPath = normalizeInternalPath(next);
   const normalizedEmail = typeof email === "string" ? email.trim().slice(0, 254) : "";
 
   return (
-    <div className="mx-auto flex min-h-[70vh] w-full max-w-5xl flex-col justify-center px-4 py-12 sm:px-6">
-      <AuthCheckEmailPanel flow={parsedFlow} email={normalizedEmail} nextPath={safeNextPath} />
-    </div>
+    <PageFrame variant="form">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-10 sm:px-6 sm:py-14">
+        <PageHero
+          badgeTone="violet"
+          eyebrow={tr(locale, "Auth flow", "Auth-процесс")}
+          title={tr(locale, "Check your inbox", "Проверьте почту")}
+          description={tr(
+            locale,
+            "Use the verification link from your email to continue sign-in or password recovery.",
+            "Используйте ссылку подтверждения из письма, чтобы продолжить вход или восстановление пароля.",
+          )}
+        />
+        <div className="rounded-2xl border border-white/10 bg-slate-950/70 p-4 sm:p-6">
+          <AuthCheckEmailPanel flow={parsedFlow} email={normalizedEmail} nextPath={safeNextPath} />
+        </div>
+      </div>
+    </PageFrame>
   );
 }

--- a/app/auth/page.tsx
+++ b/app/auth/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 
+import { PageFrame, PageHero } from "@/components/page-templates";
 import { AuthSignInPanel } from "@/components/auth-sign-in-panel";
 import { tr } from "@/lib/i18n";
 import { getLocale } from "@/lib/i18n-server";
@@ -25,13 +26,28 @@ type AuthPageProps = {
 };
 
 export default async function AuthPage({ searchParams }: AuthPageProps) {
+  const locale = await getLocale();
   const { next, error } = await searchParams;
   const nextPath = typeof next === "string" ? next : "/";
   const errorCode = typeof error === "string" ? error : undefined;
 
   return (
-    <div className="mx-auto flex min-h-[70vh] w-full max-w-5xl flex-col justify-center px-4 py-12 sm:px-6">
-      <AuthSignInPanel nextPath={nextPath} errorCode={errorCode} />
-    </div>
+    <PageFrame variant="form">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-10 sm:px-6 sm:py-14">
+        <PageHero
+          badgeTone="violet"
+          eyebrow={tr(locale, "Account access", "Доступ к аккаунту")}
+          title={tr(locale, "Sign in to DemumuMind", "Войдите в DemumuMind")}
+          description={tr(
+            locale,
+            "Authenticate to submit MCP servers, track moderation status, and manage your personal workspace.",
+            "Авторизуйтесь, чтобы отправлять MCP-серверы, отслеживать модерацию и управлять личным workspace.",
+          )}
+        />
+        <div className="rounded-2xl border border-white/10 bg-slate-950/70 p-4 sm:p-6">
+          <AuthSignInPanel nextPath={nextPath} errorCode={errorCode} />
+        </div>
+      </div>
+    </PageFrame>
   );
 }

--- a/app/auth/reset-password/page.tsx
+++ b/app/auth/reset-password/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 
+import { PageFrame, PageHero } from "@/components/page-templates";
 import { AuthResetPasswordPanel } from "@/components/auth-reset-password-panel";
 import { tr } from "@/lib/i18n";
 import { getLocale } from "@/lib/i18n-server";
@@ -17,10 +18,26 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-export default function AuthResetPasswordPage() {
+export default async function AuthResetPasswordPage() {
+  const locale = await getLocale();
+
   return (
-    <div className="mx-auto flex min-h-[70vh] w-full max-w-5xl flex-col justify-center px-4 py-12 sm:px-6">
-      <AuthResetPasswordPanel />
-    </div>
+    <PageFrame variant="form">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-10 sm:px-6 sm:py-14">
+        <PageHero
+          badgeTone="violet"
+          eyebrow={tr(locale, "Security", "Безопасность")}
+          title={tr(locale, "Reset password", "Сброс пароля")}
+          description={tr(
+            locale,
+            "Create a new password with strong complexity rules to secure your account.",
+            "Создайте новый пароль с усиленными правилами сложности для защиты аккаунта.",
+          )}
+        />
+        <div className="rounded-2xl border border-white/10 bg-slate-950/70 p-4 sm:p-6">
+          <AuthResetPasswordPanel />
+        </div>
+      </div>
+    </PageFrame>
   );
 }

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -5,6 +5,7 @@ import { ArrowLeft, CalendarDays, Clock3 } from "lucide-react";
 
 import { BlogArticleBody } from "@/components/blog/blog-article-body";
 import { BlogRelatedPosts } from "@/components/blog/blog-related-posts";
+import { PageFrame } from "@/components/page-templates";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -116,7 +117,7 @@ export default async function BlogArticlePage({ params }: BlogArticlePageProps) 
   };
 
   return (
-    <div className="relative overflow-hidden border-t border-white/10">
+    <PageFrame variant="content">
       <div className="pointer-events-none absolute inset-0 -z-10 bg-[linear-gradient(180deg,#050d1b_0%,#060b16_45%,#040811_100%)]" />
       <div className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-[420px] bg-[radial-gradient(circle_at_20%_0%,rgba(56,189,248,0.16),transparent_45%),radial-gradient(circle_at_85%_5%,rgba(139,92,246,0.18),transparent_45%)]" />
 
@@ -164,6 +165,6 @@ export default async function BlogArticlePage({ params }: BlogArticlePageProps) 
 
         <BlogRelatedPosts posts={relatedPosts} locale={locale} />
       </div>
-    </div>
+    </PageFrame>
   );
 }

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -6,6 +6,7 @@ import { BlogFeaturedPost } from "@/components/blog/blog-featured-post";
 import { BlogFilterBar } from "@/components/blog/blog-filter-bar";
 import { BlogHero } from "@/components/blog/blog-hero";
 import { BlogPostCard } from "@/components/blog/blog-post-card";
+import { PageFrame } from "@/components/page-templates";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
@@ -96,7 +97,7 @@ export default async function BlogPage({ searchParams }: BlogPageProps) {
     .filter((tagItem) => tagItem.count > 0);
 
   return (
-    <div className="relative overflow-hidden border-t border-white/10">
+    <PageFrame variant="content">
       <div className="pointer-events-none absolute inset-0 -z-10 bg-[linear-gradient(180deg,#050d1b_0%,#060b16_45%,#040811_100%)]" />
       <div className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-[500px] bg-[radial-gradient(circle_at_15%_5%,rgba(139,92,246,0.2),transparent_38%),radial-gradient(circle_at_82%_5%,rgba(56,189,248,0.14),transparent_38%)]" />
 
@@ -188,6 +189,6 @@ export default async function BlogPage({ searchParams }: BlogPageProps) {
           </div>
         </section>
       </div>
-    </div>
+    </PageFrame>
   );
 }

--- a/app/catalog/page.tsx
+++ b/app/catalog/page.tsx
@@ -1,6 +1,9 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 
 import { CatalogSection } from "@/components/catalog-section";
+import { PageFrame, PageHero, PageMetric } from "@/components/page-templates";
+import { Button } from "@/components/ui/button";
 import { getCatalogSnapshot } from "@/lib/catalog/snapshot";
 import { tr } from "@/lib/i18n";
 import { getLocale } from "@/lib/i18n-server";
@@ -23,29 +26,59 @@ export default async function CatalogPage() {
   const catalogSnapshot = await getCatalogSnapshot();
 
   return (
-    <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-4 py-10 sm:px-6 sm:py-14">
-      <div className="rounded-3xl border border-slate-200 bg-slate-50/95 p-5 shadow-xl sm:p-7">
-        <div className="mb-6 space-y-1.5">
-          <h1 className="text-3xl font-semibold tracking-tight text-blue-700">
-            {tr(locale, "AI Tools Directory", "Каталог AI-инструментов")}
-          </h1>
-          <p className="text-sm text-slate-600">
-            {tr(
-              locale,
-              "Discover the best AI tools, models, and services for your projects.",
-              "Откройте лучшие AI-инструменты, модели и сервисы для ваших проектов.",
-            )}
-          </p>
-          <p className="text-xs text-slate-500">
-            {tr(
-              locale,
-              `${catalogSnapshot.totalServers} tools available in the catalog.`,
-              `В каталоге доступно ${catalogSnapshot.totalServers} инструментов.`,
-            )}
-          </p>
-        </div>
+    <PageFrame variant="directory">
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-4 py-10 sm:px-6 sm:py-14">
+        <PageHero
+          badgeTone="cyan"
+          eyebrow={tr(locale, "Directory Control Center", "Центр управления каталогом")}
+          title={tr(locale, "Find Trusted MCP Servers Faster", "Находите проверенные MCP-серверы быстрее")}
+          description={tr(
+            locale,
+            "Search by category, auth model, and capability tags. Compare candidates side-by-side and move to integration with less rework.",
+            "Ищите по категориям, типу авторизации и capability-тегам. Сравнивайте кандидатов и переходите к интеграции без лишних переделок.",
+          )}
+          actions={
+            <>
+              <Button asChild className="h-11 rounded-xl bg-blue-500 px-6 text-white hover:bg-blue-400">
+                <Link href="/submit-server">
+                  {tr(locale, "Submit server", "Отправить сервер")}
+                </Link>
+              </Button>
+              <Button
+                asChild
+                variant="outline"
+                className="h-11 rounded-xl border-white/20 bg-slate-950/70 text-slate-100 hover:bg-slate-900"
+              >
+                <Link href="/how-to-use">
+                  {tr(locale, "Open setup guide", "Открыть гайд")}
+                </Link>
+              </Button>
+            </>
+          }
+          metrics={
+            <>
+              <PageMetric
+                label={tr(locale, "Active servers", "Активные серверы")}
+                value={catalogSnapshot.totalServers}
+              />
+              <PageMetric
+                label={tr(locale, "Published tools", "Опубликованные инструменты")}
+                value={catalogSnapshot.totalTools}
+              />
+              <PageMetric
+                label={tr(locale, "Categories", "Категории")}
+                value={catalogSnapshot.totalCategories}
+              />
+              <PageMetric
+                label={tr(locale, "Featured", "Рекомендовано")}
+                value={catalogSnapshot.featuredServers.length}
+                valueClassName="text-cyan-200"
+              />
+            </>
+          }
+        />
         <CatalogSection initialServers={catalogSnapshot.servers} />
       </div>
-    </div>
+    </PageFrame>
   );
 }

--- a/app/categories/page.tsx
+++ b/app/categories/page.tsx
@@ -1,6 +1,9 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 
 import { CatalogTaxonomyPanel } from "@/components/catalog-taxonomy-panel";
+import { PageFrame, PageHero, PageMetric, PageSection } from "@/components/page-templates";
+import { Button } from "@/components/ui/button";
 import { getCatalogSnapshot } from "@/lib/catalog/snapshot";
 import { tr } from "@/lib/i18n";
 import { getLocale } from "@/lib/i18n-server";
@@ -23,40 +26,48 @@ export default async function CategoriesPage() {
   const catalogSnapshot = await getCatalogSnapshot();
 
   return (
-    <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 py-10 sm:px-6 sm:py-14">
-      <div className="space-y-2">
-        <h1 className="text-3xl font-semibold tracking-tight text-slate-100">
-          {tr(locale, "Categories", "Категории")}
-        </h1>
-        <p className="text-sm text-slate-300">
-          {tr(
+    <PageFrame variant="directory">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 py-10 sm:px-6 sm:py-14">
+        <PageHero
+          badgeTone="emerald"
+          eyebrow={tr(locale, "Taxonomy Map", "Карта таксономии")}
+          title={tr(locale, "Catalog Categories & Languages", "Категории и языки каталога")}
+          description={tr(
             locale,
-            "Explore available taxonomy values used by the catalog filters.",
-            "Изучите значения таксономии, используемые фильтрами каталога.",
+            "Use this index to understand how servers are grouped, filtered, and discovered across the platform.",
+            "Используйте этот индекс, чтобы понять как серверы группируются, фильтруются и находятся в каталоге.",
           )}
-        </p>
-      </div>
+          actions={
+            <Button
+              asChild
+              variant="outline"
+              className="h-11 rounded-xl border-white/20 bg-slate-950/70 text-slate-100 hover:bg-slate-900"
+            >
+              <Link href="/catalog">{tr(locale, "Back to directory", "Назад в каталог")}</Link>
+            </Button>
+          }
+          metrics={
+            <>
+              <PageMetric
+                label={tr(locale, "Category options", "Категории")}
+                value={catalogSnapshot.categoryEntries.length}
+              />
+              <PageMetric
+                label={tr(locale, "Language options", "Языки")}
+                value={catalogSnapshot.languageEntries.length}
+              />
+            </>
+          }
+        />
 
-      <div className="grid gap-4 md:grid-cols-2">
-        <div className="rounded-2xl border border-white/10 bg-slate-900/70 p-4">
-          <p className="text-xs text-slate-400">{tr(locale, "Category options", "Категории")}</p>
-          <p className="text-2xl font-semibold text-slate-100">
-            {catalogSnapshot.categoryEntries.length}
-          </p>
-        </div>
-        <div className="rounded-2xl border border-white/10 bg-slate-900/70 p-4">
-          <p className="text-xs text-slate-400">{tr(locale, "Language options", "Языки")}</p>
-          <p className="text-2xl font-semibold text-slate-100">
-            {catalogSnapshot.languageEntries.length}
-          </p>
-        </div>
+        <PageSection>
+          <CatalogTaxonomyPanel
+            locale={locale}
+            categoryEntries={catalogSnapshot.categoryEntries}
+            languageEntries={catalogSnapshot.languageEntries}
+          />
+        </PageSection>
       </div>
-
-      <CatalogTaxonomyPanel
-        locale={locale}
-        categoryEntries={catalogSnapshot.categoryEntries}
-        languageEntries={catalogSnapshot.languageEntries}
-      />
-    </div>
+    </PageFrame>
   );
 }

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -13,6 +13,7 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { PageFrame } from "@/components/page-templates";
 import { tr } from "@/lib/i18n";
 import { getLocale } from "@/lib/i18n-server";
 
@@ -133,7 +134,7 @@ export default async function ContactPage() {
   const locale = await getLocale();
 
   return (
-    <div className="relative overflow-hidden border-t border-white/10">
+    <PageFrame variant="content">
       <div className="pointer-events-none absolute inset-0 -z-10 bg-[linear-gradient(180deg,#031022_0%,#050d1d_45%,#030915_100%)]" />
       <div className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-[460px] bg-[radial-gradient(circle_at_20%_5%,rgba(56,189,248,0.22),transparent_40%),radial-gradient(circle_at_80%_5%,rgba(16,185,129,0.14),transparent_38%)]" />
 
@@ -252,6 +253,6 @@ export default async function ContactPage() {
           </Card>
         </section>
       </div>
-    </div>
+    </PageFrame>
   );
 }

--- a/app/discord/page.tsx
+++ b/app/discord/page.tsx
@@ -5,6 +5,7 @@ import { type LucideIcon, ArrowRight, Bot, MessageCircleMore, ShieldCheck, Users
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { PageFrame } from "@/components/page-templates";
 import { tr } from "@/lib/i18n";
 import { getLocale } from "@/lib/i18n-server";
 
@@ -82,7 +83,7 @@ export default async function DiscordPage() {
   const locale = await getLocale();
 
   return (
-    <div className="relative overflow-hidden border-t border-white/10">
+    <PageFrame variant="content">
       <div className="pointer-events-none absolute inset-0 -z-10 bg-[linear-gradient(180deg,#0a1020_0%,#070b17_50%,#050811_100%)]" />
       <div className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-[500px] bg-[radial-gradient(circle_at_17%_7%,rgba(99,102,241,0.24),transparent_42%),radial-gradient(circle_at_84%_4%,rgba(168,85,247,0.2),transparent_38%)]" />
 
@@ -190,6 +191,6 @@ export default async function DiscordPage() {
           </Card>
         </section>
       </div>
-    </div>
+    </PageFrame>
   );
 }

--- a/app/how-to-use/page.tsx
+++ b/app/how-to-use/page.tsx
@@ -14,6 +14,7 @@ import {
 } from "lucide-react";
 
 import { HowToConnectSection } from "@/components/how-to-connect-section";
+import { PageFrame } from "@/components/page-templates";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -245,7 +246,7 @@ export default async function HowToUsePage() {
   const sampleServer = catalogSnapshot.sampleServer;
 
   return (
-    <div className="relative overflow-hidden border-t border-white/10">
+    <PageFrame variant="content">
       <div className="pointer-events-none absolute inset-0 -z-10 bg-[linear-gradient(180deg,#02070f_0%,#030a15_42%,#050814_100%)]" />
       <div className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-[520px] bg-[radial-gradient(circle_at_14%_4%,rgba(56,189,248,0.28),transparent_42%),radial-gradient(circle_at_84%_6%,rgba(59,130,246,0.18),transparent_38%)]" />
       <div className="pointer-events-none absolute inset-0 -z-10 bg-[linear-gradient(90deg,rgba(56,189,248,0.06)_1px,transparent_1px),linear-gradient(rgba(56,189,248,0.05)_1px,transparent_1px)] bg-[size:42px_42px] opacity-30" />
@@ -487,6 +488,6 @@ export default async function HowToUsePage() {
           </div>
         </div>
       </section>
-    </div>
+    </PageFrame>
   );
 }

--- a/app/mcp/page.tsx
+++ b/app/mcp/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { ArrowRight, CheckCircle2, ShieldCheck, Sparkles } from "lucide-react";
 
+import { PageFrame, PageHero, PageSection } from "@/components/page-templates";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { tr } from "@/lib/i18n";
@@ -54,49 +55,55 @@ export default async function MCPPage() {
   ];
 
   return (
-    <div className="mx-auto flex w-full max-w-6xl flex-col gap-8 px-4 py-10 sm:px-6 sm:py-14">
-      <section className="space-y-3 rounded-2xl border border-white/10 bg-slate-900/55 p-6 sm:p-8">
-        <h1 className="text-3xl font-semibold tracking-tight text-slate-100">MCP</h1>
-        <p className="max-w-3xl text-sm text-slate-300">
-          {tr(
+    <PageFrame variant="marketing">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-8 px-4 py-10 sm:px-6 sm:py-14">
+        <PageHero
+          badgeTone="cyan"
+          eyebrow={tr(locale, "MCP Foundation", "Основа MCP")}
+          title={tr(locale, "One Operating Layer for MCP Delivery", "Единый операционный слой для MCP-доставки")}
+          description={tr(
             locale,
-            "Discover verified and community MCP servers, inspect tool capabilities, and connect them to your AI workflows.",
-            "Находите верифицированные и community MCP-серверы, проверяйте возможности инструментов и подключайте их к AI-workflow.",
+            "DemumuMind combines discovery, trust signals, and operational checklists so teams can adopt MCP servers with confidence.",
+            "DemumuMind объединяет discovery, сигналы доверия и операционные чеклисты, чтобы команды внедряли MCP-серверы с уверенностью.",
           )}
-        </p>
-        <div className="flex flex-wrap items-center gap-3">
-          <Button asChild className="bg-blue-500 hover:bg-blue-400">
-            <Link href="/catalog">
-              {tr(locale, "Browse catalog", "Открыть каталог")}
-              <ArrowRight className="size-4" />
-            </Link>
-          </Button>
-          <Button
-            asChild
-            variant="outline"
-            className="border-white/15 bg-white/[0.02] hover:bg-white/[0.06]"
-          >
-            <Link href="/how-to-use">{tr(locale, "Open setup guide", "Открыть гайд")}</Link>
-          </Button>
-        </div>
-      </section>
+          actions={
+            <>
+              <Button asChild className="bg-blue-500 hover:bg-blue-400">
+                <Link href="/catalog">
+                  {tr(locale, "Browse catalog", "Открыть каталог")}
+                  <ArrowRight className="size-4" />
+                </Link>
+              </Button>
+              <Button
+                asChild
+                variant="outline"
+                className="border-white/15 bg-white/[0.02] hover:bg-white/[0.06]"
+              >
+                <Link href="/how-to-use">{tr(locale, "Open setup guide", "Открыть гайд")}</Link>
+              </Button>
+            </>
+          }
+        />
 
-      <section className="grid gap-4 md:grid-cols-3" aria-label="MCP highlights">
-        {highlights.map((item) => (
-          <Card
-            key={item.title}
-            className="border-white/10 bg-slate-900/70 shadow-[0_0_0_1px_rgba(148,163,184,0.07)] backdrop-blur"
-          >
-            <CardHeader className="pb-2">
-              <CardTitle className="flex items-center gap-2 text-base text-slate-100">
-                <item.icon className="size-4 text-blue-400" />
-                {item.title}
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="text-sm text-slate-300">{item.description}</CardContent>
-          </Card>
-        ))}
-      </section>
-    </div>
+        <PageSection>
+          <section className="grid gap-4 md:grid-cols-3" aria-label="MCP highlights">
+            {highlights.map((item) => (
+              <Card
+                key={item.title}
+                className="border-white/10 bg-slate-900/70 shadow-[0_0_0_1px_rgba(148,163,184,0.07)] backdrop-blur"
+              >
+                <CardHeader className="pb-2">
+                  <CardTitle className="flex items-center gap-2 text-base text-slate-100">
+                    <item.icon className="size-4 text-blue-400" />
+                    {item.title}
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="text-sm text-slate-300">{item.description}</CardContent>
+              </Card>
+            ))}
+          </section>
+        </PageSection>
+      </div>
+    </PageFrame>
   );
 }

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -1,7 +1,8 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { CheckCircle2 } from "lucide-react";
+import { CheckCircle2, Sparkles } from "lucide-react";
 
+import { PageFrame, PageHero, PageMetric, PageSection } from "@/components/page-templates";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { tr } from "@/lib/i18n";
@@ -24,48 +25,100 @@ export default async function PricingPage() {
   const locale = await getLocale();
 
   return (
-    <div className="mx-auto flex w-full max-w-4xl flex-col gap-6 px-4 py-10 sm:px-6 sm:py-14">
-      <div className="space-y-2">
-        <h1 className="text-3xl font-semibold tracking-tight text-slate-100">
-          {tr(locale, "Pricing", "Цены")}
-        </h1>
-        <p className="text-sm text-slate-300">
-          {tr(
+    <PageFrame variant="marketing">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-10 sm:px-6 sm:py-14">
+        <PageHero
+          badgeTone="emerald"
+          eyebrow={tr(locale, "Commercial model", "Коммерческая модель")}
+          title={tr(locale, "Simple Pricing for Early Teams", "Прозрачные цены для команд на старте")}
+          description={tr(
             locale,
-            "Catalog browsing and server discovery are currently free.",
-            "Просмотр каталога и поиск серверов сейчас бесплатны.",
+            "Directory access and server discovery remain free while we roll out advanced collaboration and governance modules.",
+            "Доступ к каталогу и discovery серверов остаются бесплатными, пока мы развиваем расширенные модули совместной работы и governance.",
           )}
-        </p>
-      </div>
+          metrics={
+            <>
+              <PageMetric
+                label={tr(locale, "Current plan", "Текущий план")}
+                value={tr(locale, "Free", "Бесплатно")}
+                valueClassName="text-emerald-200"
+              />
+              <PageMetric
+                label={tr(locale, "Status", "Статус")}
+                value={tr(locale, "Public beta", "Публичная бета")}
+              />
+            </>
+          }
+        />
 
-      <Card className="border-white/10 bg-slate-900/70">
-        <CardHeader className="pb-2">
-          <CardTitle className="text-xl text-slate-100">
-            {tr(locale, "Current plan: Free", "Текущий план: Free")}
-          </CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-3 text-sm text-slate-300">
-          <div className="flex items-start gap-2">
-            <CheckCircle2 className="mt-0.5 size-4 text-emerald-300" />
-            <p>{tr(locale, "Browse verified and community MCP server listings.", "Просматривайте верифицированные и community MCP-серверы.")}</p>
-          </div>
-          <div className="flex items-start gap-2">
-            <CheckCircle2 className="mt-0.5 size-4 text-emerald-300" />
-            <p>{tr(locale, "Use category, language, and auth filters in the catalog.", "Используйте фильтры по категориям, языкам и авторизации.")}</p>
-          </div>
-          <div className="flex items-start gap-2">
-            <CheckCircle2 className="mt-0.5 size-4 text-emerald-300" />
-            <p>{tr(locale, "Submit your MCP server after login for moderation.", "Отправляйте MCP-сервер на модерацию после входа.")}</p>
-          </div>
-          <Button
-            asChild
-            variant="outline"
-            className="border-white/15 bg-white/[0.02] hover:bg-white/[0.06]"
-          >
-            <Link href="/catalog">{tr(locale, "Go to catalog", "Перейти в каталог")}</Link>
-          </Button>
-        </CardContent>
-      </Card>
-    </div>
+        <PageSection>
+          <Card className="border-white/10 bg-slate-900/70">
+            <CardHeader className="pb-2">
+              <CardTitle className="text-xl text-slate-100">
+                {tr(locale, "Current plan: Free", "Текущий план: Free")}
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3 text-sm text-slate-300">
+              <div className="flex items-start gap-2">
+                <CheckCircle2 className="mt-0.5 size-4 text-emerald-300" />
+                <p>
+                  {tr(
+                    locale,
+                    "Browse verified and community MCP server listings.",
+                    "Просматривайте верифицированные и community MCP-серверы.",
+                  )}
+                </p>
+              </div>
+              <div className="flex items-start gap-2">
+                <CheckCircle2 className="mt-0.5 size-4 text-emerald-300" />
+                <p>
+                  {tr(
+                    locale,
+                    "Use category, language, and auth filters in the catalog.",
+                    "Используйте фильтры по категориям, языкам и авторизации.",
+                  )}
+                </p>
+              </div>
+              <div className="flex items-start gap-2">
+                <CheckCircle2 className="mt-0.5 size-4 text-emerald-300" />
+                <p>
+                  {tr(
+                    locale,
+                    "Submit your MCP server after login for moderation.",
+                    "Отправляйте MCP-сервер на модерацию после входа.",
+                  )}
+                </p>
+              </div>
+              <div className="rounded-xl border border-emerald-400/25 bg-emerald-500/10 px-3 py-2 text-xs text-emerald-100">
+                <p className="inline-flex items-center gap-1.5">
+                  <Sparkles className="size-3.5" />
+                  {tr(
+                    locale,
+                    "Roadmap: team seats, moderation SLAs, and managed private catalogs.",
+                    "Roadmap: командные места, SLA модерации и управляемые приватные каталоги.",
+                  )}
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-3">
+                <Button
+                  asChild
+                  variant="outline"
+                  className="border-white/15 bg-white/[0.02] hover:bg-white/[0.06]"
+                >
+                  <Link href="/catalog">{tr(locale, "Go to catalog", "Перейти в каталог")}</Link>
+                </Button>
+                <Button
+                  asChild
+                  variant="outline"
+                  className="border-white/15 bg-white/[0.02] hover:bg-white/[0.06]"
+                >
+                  <Link href="/contact">{tr(locale, "Contact sales", "Связаться с продажами")}</Link>
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        </PageSection>
+      </div>
+    </PageFrame>
   );
 }

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,5 +1,8 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 
+import { PageFrame, PageHero, PageSection } from "@/components/page-templates";
+import { Button } from "@/components/ui/button";
 import { tr } from "@/lib/i18n";
 import { getLocale } from "@/lib/i18n-server";
 import {
@@ -26,56 +29,90 @@ export default async function PrivacyPage() {
   const locale = await getLocale();
 
   return (
-    <div className="mx-auto flex w-full max-w-4xl flex-col gap-8 px-4 py-12 sm:px-6">
-      <header className="space-y-2">
-        <h1 className="text-3xl font-semibold text-slate-100">
-          {tr(locale, "Privacy Policy", "Политика конфиденциальности")}
-        </h1>
-        <p className="text-sm text-slate-400">
-          {tr(locale, "Last updated:", "Последнее обновление:")} {getLegalLastUpdatedValue(locale)}
-        </p>
-      </header>
+    <PageFrame variant="content">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-10 sm:px-6 sm:py-14">
+        <PageHero
+          badgeTone="violet"
+          eyebrow={tr(locale, "Legal", "Юридическая информация")}
+          title={tr(locale, "Privacy Policy", "Политика конфиденциальности")}
+          description={tr(
+            locale,
+            "How DemumuMind collects, uses, and protects data across account, catalog, and submission workflows.",
+            "Как DemumuMind собирает, использует и защищает данные в аккаунте, каталоге и workflow отправки.",
+          )}
+          actions={
+            <div className="flex flex-wrap gap-3">
+              <Button
+                asChild
+                variant="outline"
+                className="h-11 rounded-xl border-white/20 bg-slate-950/70 text-slate-100 hover:bg-slate-900"
+              >
+                <Link href="/terms">{tr(locale, "Open Terms", "Открыть условия")}</Link>
+              </Button>
+              <Button
+                asChild
+                variant="outline"
+                className="h-11 rounded-xl border-white/20 bg-slate-950/70 text-slate-100 hover:bg-slate-900"
+              >
+                <Link href="/contact">{tr(locale, "Contact legal", "Связаться с legal")}</Link>
+              </Button>
+            </div>
+          }
+          metrics={
+            <div className="rounded-xl border border-white/10 bg-slate-900/70 px-4 py-3">
+              <p className="text-[11px] tracking-[0.14em] text-slate-400 uppercase">
+                {tr(locale, "Last updated", "Последнее обновление")}
+              </p>
+              <p className="mt-1 text-sm font-semibold text-slate-100">
+                {getLegalLastUpdatedValue(locale)}
+              </p>
+            </div>
+          }
+        />
 
-      {privacySections.map((section) => (
-        <section key={section.id} className="space-y-3 border-t border-white/10 pt-5">
-          <h2 className="text-2xl font-semibold text-slate-100">
-            {tr(locale, section.title.en, section.title.ru)}
-          </h2>
+        <PageSection className="space-y-6">
+          {privacySections.map((section) => (
+            <section key={section.id} className="space-y-3 border-t border-white/10 pt-5 first:border-none first:pt-0">
+              <h2 className="text-2xl font-semibold text-slate-100">
+                {tr(locale, section.title.en, section.title.ru)}
+              </h2>
 
-          {section.paragraph ? (
+              {section.paragraph ? (
+                <p className="text-base leading-8 text-slate-300">
+                  {tr(locale, section.paragraph.en, section.paragraph.ru)}
+                </p>
+              ) : null}
+
+              {section.bullets ? (
+                <ul className="space-y-3 pl-5 text-base leading-8 text-slate-300">
+                  {section.bullets.map((bullet) => (
+                    <li key={bullet.en} className="list-disc marker:text-sky-400">
+                      {tr(locale, bullet.en, bullet.ru)}
+                    </li>
+                  ))}
+                </ul>
+              ) : null}
+            </section>
+          ))}
+
+          <section className="space-y-3 border-t border-white/10 pt-5">
+            <h2 className="text-2xl font-semibold text-slate-100">
+              {tr(locale, "9. Contact", "9. Контакты")}
+            </h2>
             <p className="text-base leading-8 text-slate-300">
-              {tr(locale, section.paragraph.en, section.paragraph.ru)}
+              {tr(locale, "Email:", "Email:")}{" "}
+              <a
+                href={legalGmailComposeUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="text-sky-300 underline underline-offset-2 transition hover:text-sky-200"
+              >
+                {legalEmail}
+              </a>
             </p>
-          ) : null}
-
-          {section.bullets ? (
-            <ul className="space-y-3 pl-5 text-base leading-8 text-slate-300">
-              {section.bullets.map((bullet) => (
-                <li key={bullet.en} className="list-disc marker:text-sky-400">
-                  {tr(locale, bullet.en, bullet.ru)}
-                </li>
-              ))}
-            </ul>
-          ) : null}
-        </section>
-      ))}
-
-      <section className="space-y-3 border-t border-white/10 pt-5">
-        <h2 className="text-2xl font-semibold text-slate-100">
-          {tr(locale, "9. Contact", "9. Контакты")}
-        </h2>
-        <p className="text-base leading-8 text-slate-300">
-          {tr(locale, "Email:", "Email:")}{" "}
-          <a
-            href={legalGmailComposeUrl}
-            target="_blank"
-            rel="noreferrer"
-            className="text-sky-300 underline underline-offset-2 transition hover:text-sky-200"
-          >
-            {legalEmail}
-          </a>
-        </p>
-      </section>
-    </div>
+          </section>
+        </PageSection>
+      </div>
+    </PageFrame>
   );
 }

--- a/app/server/[slug]/page.tsx
+++ b/app/server/[slug]/page.tsx
@@ -13,6 +13,7 @@ import {
   Users,
 } from "lucide-react";
 
+import { PageFrame } from "@/components/page-templates";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
@@ -154,107 +155,109 @@ export default async function ServerDetailPage({ params }: ServerDetailPageProps
   };
 
   return (
-    <div className="mx-auto w-full max-w-4xl px-4 py-10 sm:px-6">
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
-      />
+    <PageFrame variant="directory">
+      <div className="mx-auto w-full max-w-4xl px-4 py-10 sm:px-6 sm:py-14">
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
 
-      <div className="mb-6">
-        <Button asChild variant="ghost" className="px-0 text-slate-300 hover:text-white">
-          <Link href="/">
-            <ArrowLeft className="size-4" />
-            {tr(locale, "Back to catalog", "Назад в каталог")}
-          </Link>
-        </Button>
-      </div>
+        <div className="mb-6">
+          <Button asChild variant="ghost" className="px-0 text-slate-300 hover:text-white">
+            <Link href="/catalog">
+              <ArrowLeft className="size-4" />
+              {tr(locale, "Back to catalog", "Назад в каталог")}
+            </Link>
+          </Button>
+        </div>
 
-      <Card className="border-white/10 bg-slate-900/70">
-        <CardHeader className="space-y-4">
-          <div className="flex flex-wrap items-start justify-between gap-3">
-            <div className="space-y-2">
-              <h1 className="text-3xl font-semibold tracking-tight text-slate-100">
-                {mcpServer.name}
-              </h1>
-              <p className="text-sm text-slate-300">{mcpServer.description}</p>
-            </div>
-
-            <div className="flex flex-wrap gap-2">
-              <Badge className="bg-blue-500/15 text-blue-300">{mcpServer.category}</Badge>
-              <Badge variant="outline" className="border-white/10 bg-slate-950/70 text-slate-300">
-                <AuthIcon className="mr-1 size-3" />
-                {tr(locale, authBadge.labelEn, authBadge.labelRu)}
-              </Badge>
-              <Badge variant="outline" className="border-white/15 text-slate-300">
-                <VerificationIcon className="mr-1 size-3" />
-                {tr(locale, verificationBadge.labelEn, verificationBadge.labelRu)}
-              </Badge>
-              <Badge variant="outline" className={healthBadge.className}>
-                <span className={`mr-1 inline-block size-1.5 rounded-full ${healthBadge.dotClassName}`} />
-                {tr(locale, healthBadge.labelEn, healthBadge.labelRu)}
-              </Badge>
-            </div>
-          </div>
-        </CardHeader>
-
-        <CardContent className="space-y-6">
-          <div className="rounded-xl border border-white/10 bg-slate-950/70 p-4">
-            <p className="mb-2 text-xs font-medium tracking-wide text-slate-400 uppercase">
-              {tr(locale, "Server URL", "URL сервера")}
-            </p>
-            <p className="break-all text-sm text-slate-200">{mcpServer.serverUrl}</p>
-          </div>
-
-          <div className="space-y-3">
-            <h2 className="text-lg font-medium text-slate-100">
-              {tr(locale, "Available tools", "Доступные инструменты")}
-            </h2>
-            {mcpServer.tools.length > 0 ? (
-              <div className="flex flex-wrap gap-2">
-                {mcpServer.tools.map((toolName) => (
-                  <Badge key={toolName} variant="outline" className="border-white/12 text-slate-300">
-                    {toolName}
-                  </Badge>
-                ))}
+        <Card className="border-white/10 bg-slate-900/70">
+          <CardHeader className="space-y-4">
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div className="space-y-2">
+                <h1 className="text-3xl font-semibold tracking-tight text-slate-100">
+                  {mcpServer.name}
+                </h1>
+                <p className="text-sm text-slate-300">{mcpServer.description}</p>
               </div>
-            ) : (
-              <p className="text-sm text-slate-400">
-                {tr(locale, "No tool list published yet.", "Список инструментов пока не опубликован.")}
-              </p>
-            )}
-          </div>
 
-          <div className="rounded-xl border border-white/10 bg-slate-950/70 p-4">
-            <p className="mb-2 text-xs font-medium tracking-wide text-slate-400 uppercase">
-              {tr(locale, "Health check", "Проверка состояния")}
-            </p>
-            <div className="flex flex-wrap items-center gap-3 text-sm text-slate-300">
-              <span>
-                {tr(locale, "Status", "Статус")}: {tr(locale, healthBadge.labelEn, healthBadge.labelRu)}
-              </span>
-              <span>
-                {tr(locale, "Last checked", "Последняя проверка")}: {formatCheckedAt(mcpServer.healthCheckedAt, locale)}
-              </span>
+              <div className="flex flex-wrap gap-2">
+                <Badge className="bg-blue-500/15 text-blue-300">{mcpServer.category}</Badge>
+                <Badge variant="outline" className="border-white/10 bg-slate-950/70 text-slate-300">
+                  <AuthIcon className="mr-1 size-3" />
+                  {tr(locale, authBadge.labelEn, authBadge.labelRu)}
+                </Badge>
+                <Badge variant="outline" className="border-white/15 text-slate-300">
+                  <VerificationIcon className="mr-1 size-3" />
+                  {tr(locale, verificationBadge.labelEn, verificationBadge.labelRu)}
+                </Badge>
+                <Badge variant="outline" className={healthBadge.className}>
+                  <span className={`mr-1 inline-block size-1.5 rounded-full ${healthBadge.dotClassName}`} />
+                  {tr(locale, healthBadge.labelEn, healthBadge.labelRu)}
+                </Badge>
+              </div>
             </div>
-            {mcpServer.healthError ? (
-              <p className="mt-2 text-xs text-rose-200">
-                {tr(locale, "Last error", "Последняя ошибка")}: {mcpServer.healthError}
-              </p>
-            ) : null}
-          </div>
+          </CardHeader>
 
-          <div className="flex flex-wrap gap-3">
-            {visitUrl ? (
-              <Button asChild className="bg-blue-500 hover:bg-blue-400">
-                <Link href={visitUrl} target="_blank" rel="noreferrer">
-                  {tr(locale, "Visit", "Открыть")}
-                  <ExternalLink className="size-4" />
-                </Link>
-              </Button>
-            ) : null}
-          </div>
-        </CardContent>
-      </Card>
-    </div>
+          <CardContent className="space-y-6">
+            <div className="rounded-xl border border-white/10 bg-slate-950/70 p-4">
+              <p className="mb-2 text-xs font-medium tracking-wide text-slate-400 uppercase">
+                {tr(locale, "Server URL", "URL сервера")}
+              </p>
+              <p className="break-all text-sm text-slate-200">{mcpServer.serverUrl}</p>
+            </div>
+
+            <div className="space-y-3">
+              <h2 className="text-lg font-medium text-slate-100">
+                {tr(locale, "Available tools", "Доступные инструменты")}
+              </h2>
+              {mcpServer.tools.length > 0 ? (
+                <div className="flex flex-wrap gap-2">
+                  {mcpServer.tools.map((toolName) => (
+                    <Badge key={toolName} variant="outline" className="border-white/12 text-slate-300">
+                      {toolName}
+                    </Badge>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-sm text-slate-400">
+                  {tr(locale, "No tool list published yet.", "Список инструментов пока не опубликован.")}
+                </p>
+              )}
+            </div>
+
+            <div className="rounded-xl border border-white/10 bg-slate-950/70 p-4">
+              <p className="mb-2 text-xs font-medium tracking-wide text-slate-400 uppercase">
+                {tr(locale, "Health check", "Проверка состояния")}
+              </p>
+              <div className="flex flex-wrap items-center gap-3 text-sm text-slate-300">
+                <span>
+                  {tr(locale, "Status", "Статус")}: {tr(locale, healthBadge.labelEn, healthBadge.labelRu)}
+                </span>
+                <span>
+                  {tr(locale, "Last checked", "Последняя проверка")}: {formatCheckedAt(mcpServer.healthCheckedAt, locale)}
+                </span>
+              </div>
+              {mcpServer.healthError ? (
+                <p className="mt-2 text-xs text-rose-200">
+                  {tr(locale, "Last error", "Последняя ошибка")}: {mcpServer.healthError}
+                </p>
+              ) : null}
+            </div>
+
+            <div className="flex flex-wrap gap-3">
+              {visitUrl ? (
+                <Button asChild className="bg-blue-500 hover:bg-blue-400">
+                  <Link href={visitUrl} target="_blank" rel="noreferrer">
+                    {tr(locale, "Visit", "Открыть")}
+                    <ExternalLink className="size-4" />
+                  </Link>
+                </Button>
+              ) : null}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </PageFrame>
   );
 }

--- a/app/sitemap/page.tsx
+++ b/app/sitemap/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 
-import { BridgePageShell } from "@/components/bridge-page-shell";
+import { PageFrame, PageHero, PageSection } from "@/components/page-templates";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { tr } from "@/lib/i18n";
 import { getLocale } from "@/lib/i18n-server";
@@ -43,8 +43,8 @@ const sections: readonly SiteMapSection[] = [
       {
         href: "/about",
         title: {
-          en: "About BridgeMind",
-          ru: "О BridgeMind",
+          en: "About DemumuMind",
+          ru: "О DemumuMind",
         },
         description: {
           en: "Mission, vision, and operating model for MCP delivery.",
@@ -103,12 +103,12 @@ const sections: readonly SiteMapSection[] = [
       {
         href: "/discord",
         title: {
-          en: "Discord Community",
+          en: "Discord community",
           ru: "Discord-сообщество",
         },
         description: {
-          en: "Join the BridgeMind developer community.",
-          ru: "Присоединяйтесь к сообществу разработчиков BridgeMind.",
+          en: "Join the DemumuMind developer community.",
+          ru: "Присоединяйтесь к сообществу разработчиков DemumuMind.",
         },
       },
       {
@@ -163,8 +163,8 @@ export async function generateMetadata(): Promise<Metadata> {
     title: tr(locale, "Sitemap", "Карта сайта"),
     description: tr(
       locale,
-      "Full BridgeMind site navigation.",
-      "Полная навигация по сайту BridgeMind.",
+      "Full DemumuMind site navigation.",
+      "Полная навигация по сайту DemumuMind.",
     ),
   };
 }
@@ -173,63 +173,64 @@ export default async function SitemapPage() {
   const locale = await getLocale();
 
   return (
-    <div className="space-y-6 pb-12">
-      <BridgePageShell
-        eyebrow={tr(locale, "Navigation", "Навигация")}
-        title={tr(locale, "BridgeMind Sitemap", "Карта сайта BridgeMind")}
-        description={tr(
-          locale,
-          "A complete index of core pages, resources, community hubs, and policy pages.",
-          "Полный индекс ключевых страниц, ресурсов, community-разделов и policy-документов.",
-        )}
-        links={[
-          {
-            href: "/sitemap.xml",
-            label: tr(locale, "Machine-readable sitemap.xml", "Машиночитаемый sitemap.xml"),
-            description: tr(
-              locale,
-              "XML sitemap for search engines and crawlers.",
-              "XML-карта сайта для поисковых систем и краулеров.",
-            ),
-          },
-          {
-            href: "/llms.txt",
-            label: tr(locale, "Machine-readable llms.txt", "Машиночитаемый llms.txt"),
-            description: tr(
-              locale,
-              "Structured overview for AI assistants and LLM crawlers.",
-              "Структурированное описание сайта для AI-ассистентов и LLM-краулеров.",
-            ),
-          },
-        ]}
-      />
-
-      <div className="mx-auto grid w-full max-w-5xl gap-5 px-4 sm:px-6">
-        {sections.map((section) => (
-          <section key={section.title.en} className="space-y-3">
-            <h2 className="text-xs font-semibold tracking-[0.18em] text-slate-400 uppercase">
-              {tr(locale, section.title.en, section.title.ru)}
-            </h2>
-
-            <div className="grid gap-3 sm:grid-cols-2">
-              {section.links.map((item) => (
-                <Card key={item.href} className="border-white/10 bg-slate-900/65">
-                  <CardHeader className="pb-2">
-                    <CardTitle className="text-base text-slate-100">
-                      <Link href={item.href} className="transition hover:text-white">
-                        {tr(locale, item.title.en, item.title.ru)}
-                      </Link>
-                    </CardTitle>
-                  </CardHeader>
-                  <CardContent className="text-sm text-slate-300">
-                    {tr(locale, item.description.en, item.description.ru)}
-                  </CardContent>
-                </Card>
-              ))}
+    <PageFrame variant="content">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-10 sm:px-6 sm:py-14">
+        <PageHero
+          badgeTone="violet"
+          eyebrow={tr(locale, "Navigation", "Навигация")}
+          title={tr(locale, "DemumuMind Sitemap", "Карта сайта DemumuMind")}
+          description={tr(
+            locale,
+            "A complete index of core pages, resources, community hubs, and legal documents.",
+            "Полный индекс ключевых страниц, ресурсов, community-разделов и юридических документов.",
+          )}
+          actions={
+            <div className="flex flex-wrap gap-3">
+              <Link
+                href="/sitemap.xml"
+                className="inline-flex h-11 items-center rounded-xl border border-white/20 bg-slate-950/70 px-4 text-sm text-slate-100 transition hover:bg-slate-900"
+              >
+                {tr(locale, "Open sitemap.xml", "Открыть sitemap.xml")}
+              </Link>
+              <Link
+                href="/llms.txt"
+                className="inline-flex h-11 items-center rounded-xl border border-white/20 bg-slate-950/70 px-4 text-sm text-slate-100 transition hover:bg-slate-900"
+              >
+                {tr(locale, "Open llms.txt", "Открыть llms.txt")}
+              </Link>
             </div>
-          </section>
-        ))}
+          }
+        />
+
+        <PageSection>
+          <div className="grid gap-5">
+            {sections.map((section) => (
+              <section key={section.title.en} className="space-y-3">
+                <h2 className="text-xs font-semibold tracking-[0.18em] text-slate-400 uppercase">
+                  {tr(locale, section.title.en, section.title.ru)}
+                </h2>
+
+                <div className="grid gap-3 sm:grid-cols-2">
+                  {section.links.map((item) => (
+                    <Card key={item.href} className="border-white/10 bg-slate-900/65">
+                      <CardHeader className="pb-2">
+                        <CardTitle className="text-base text-slate-100">
+                          <Link href={item.href} className="transition hover:text-white">
+                            {tr(locale, item.title.en, item.title.ru)}
+                          </Link>
+                        </CardTitle>
+                      </CardHeader>
+                      <CardContent className="text-sm text-slate-300">
+                        {tr(locale, item.description.en, item.description.ru)}
+                      </CardContent>
+                    </Card>
+                  ))}
+                </div>
+              </section>
+            ))}
+          </div>
+        </PageSection>
       </div>
-    </div>
+    </PageFrame>
   );
 }

--- a/app/submit-server/page.tsx
+++ b/app/submit-server/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { ArrowRight, CheckCircle2, LayoutDashboard, ShieldCheck, Sparkles } from "lucide-react";
 
 import { SubmissionAccessPanel } from "@/components/submission-access-panel";
+import { PageFrame } from "@/components/page-templates";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -62,7 +63,7 @@ export default async function SubmitServerPage() {
   const locale = await getLocale();
 
   return (
-    <div className="relative overflow-hidden border-t border-white/10">
+    <PageFrame variant="form">
       <div className="pointer-events-none absolute inset-0 -z-10 bg-[linear-gradient(180deg,#02050f_0%,#050a18_45%,#090816_100%)]" />
       <div className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-[480px] bg-[radial-gradient(circle_at_16%_8%,rgba(217,70,239,0.2),transparent_42%),radial-gradient(circle_at_84%_10%,rgba(59,130,246,0.18),transparent_40%)]" />
 
@@ -140,6 +141,6 @@ export default async function SubmitServerPage() {
           <SubmissionAccessPanel />
         </div>
       </section>
-    </div>
+    </PageFrame>
   );
 }

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,5 +1,8 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 
+import { PageFrame, PageHero, PageSection } from "@/components/page-templates";
+import { Button } from "@/components/ui/button";
 import { tr } from "@/lib/i18n";
 import { getLocale } from "@/lib/i18n-server";
 import {
@@ -26,56 +29,90 @@ export default async function TermsPage() {
   const locale = await getLocale();
 
   return (
-    <div className="mx-auto flex w-full max-w-4xl flex-col gap-8 px-4 py-12 sm:px-6">
-      <header className="space-y-2">
-        <h1 className="text-3xl font-semibold text-slate-100">
-          {tr(locale, "Terms of Service", "Пользовательское соглашение")}
-        </h1>
-        <p className="text-sm text-slate-400">
-          {tr(locale, "Last updated:", "Последнее обновление:")} {getLegalLastUpdatedValue(locale)}
-        </p>
-      </header>
+    <PageFrame variant="content">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-10 sm:px-6 sm:py-14">
+        <PageHero
+          badgeTone="violet"
+          eyebrow={tr(locale, "Legal", "Юридическая информация")}
+          title={tr(locale, "Terms of Service", "Пользовательское соглашение")}
+          description={tr(
+            locale,
+            "Rules and responsibilities for using DemumuMind services, workflows, and community features.",
+            "Правила и ответственность при использовании сервисов DemumuMind, workflow и community-функций.",
+          )}
+          actions={
+            <div className="flex flex-wrap gap-3">
+              <Button
+                asChild
+                variant="outline"
+                className="h-11 rounded-xl border-white/20 bg-slate-950/70 text-slate-100 hover:bg-slate-900"
+              >
+                <Link href="/privacy">{tr(locale, "Open Privacy Policy", "Открыть политику конфиденциальности")}</Link>
+              </Button>
+              <Button
+                asChild
+                variant="outline"
+                className="h-11 rounded-xl border-white/20 bg-slate-950/70 text-slate-100 hover:bg-slate-900"
+              >
+                <Link href="/contact">{tr(locale, "Contact legal", "Связаться с legal")}</Link>
+              </Button>
+            </div>
+          }
+          metrics={
+            <div className="rounded-xl border border-white/10 bg-slate-900/70 px-4 py-3">
+              <p className="text-[11px] tracking-[0.14em] text-slate-400 uppercase">
+                {tr(locale, "Last updated", "Последнее обновление")}
+              </p>
+              <p className="mt-1 text-sm font-semibold text-slate-100">
+                {getLegalLastUpdatedValue(locale)}
+              </p>
+            </div>
+          }
+        />
 
-      {termsSections.map((section) => (
-        <section key={section.id} className="space-y-3 border-t border-white/10 pt-5">
-          <h2 className="text-2xl font-semibold text-slate-100">
-            {tr(locale, section.title.en, section.title.ru)}
-          </h2>
+        <PageSection className="space-y-6">
+          {termsSections.map((section) => (
+            <section key={section.id} className="space-y-3 border-t border-white/10 pt-5 first:border-none first:pt-0">
+              <h2 className="text-2xl font-semibold text-slate-100">
+                {tr(locale, section.title.en, section.title.ru)}
+              </h2>
 
-          {section.paragraph ? (
+              {section.paragraph ? (
+                <p className="text-base leading-8 text-slate-300">
+                  {tr(locale, section.paragraph.en, section.paragraph.ru)}
+                </p>
+              ) : null}
+
+              {section.bullets ? (
+                <ul className="space-y-3 pl-5 text-base leading-8 text-slate-300">
+                  {section.bullets.map((bullet) => (
+                    <li key={bullet.en} className="list-disc marker:text-sky-400">
+                      {tr(locale, bullet.en, bullet.ru)}
+                    </li>
+                  ))}
+                </ul>
+              ) : null}
+            </section>
+          ))}
+
+          <section className="space-y-3 border-t border-white/10 pt-5">
+            <h2 className="text-2xl font-semibold text-slate-100">
+              {tr(locale, "12. Contact", "12. Контакты")}
+            </h2>
             <p className="text-base leading-8 text-slate-300">
-              {tr(locale, section.paragraph.en, section.paragraph.ru)}
+              {tr(locale, "Email:", "Email:")}{" "}
+              <a
+                href={legalGmailComposeUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="text-sky-300 underline underline-offset-2 transition hover:text-sky-200"
+              >
+                {legalEmail}
+              </a>
             </p>
-          ) : null}
-
-          {section.bullets ? (
-            <ul className="space-y-3 pl-5 text-base leading-8 text-slate-300">
-              {section.bullets.map((bullet) => (
-                <li key={bullet.en} className="list-disc marker:text-sky-400">
-                  {tr(locale, bullet.en, bullet.ru)}
-                </li>
-              ))}
-            </ul>
-          ) : null}
-        </section>
-      ))}
-
-      <section className="space-y-3 border-t border-white/10 pt-5">
-        <h2 className="text-2xl font-semibold text-slate-100">
-          {tr(locale, "12. Contact", "12. Контакты")}
-        </h2>
-        <p className="text-base leading-8 text-slate-300">
-          {tr(locale, "Email:", "Email:")}{" "}
-          <a
-            href={legalGmailComposeUrl}
-            target="_blank"
-            rel="noreferrer"
-            className="text-sky-300 underline underline-offset-2 transition hover:text-sky-200"
-          >
-            {legalEmail}
-          </a>
-        </p>
-      </section>
-    </div>
+          </section>
+        </PageSection>
+      </div>
+    </PageFrame>
   );
 }

--- a/app/tools/page.tsx
+++ b/app/tools/page.tsx
@@ -1,6 +1,9 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 
+import { PageFrame, PageHero } from "@/components/page-templates";
 import { ToolsSection } from "@/components/tools-section";
+import { Button } from "@/components/ui/button";
 import { tr } from "@/lib/i18n";
 import { getLocale } from "@/lib/i18n-server";
 
@@ -21,24 +24,31 @@ export default async function ToolsPage() {
   const locale = await getLocale();
 
   return (
-    <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 py-10 sm:px-6 sm:py-14">
-      <div className="space-y-2">
-        <h1 className="text-3xl font-semibold tracking-tight text-slate-100">
-          {tr(
+    <PageFrame variant="marketing">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 py-10 sm:px-6 sm:py-14">
+        <PageHero
+          badgeTone="amber"
+          eyebrow={tr(locale, "Builder Utilities", "Инструменты разработчика")}
+          title={tr(locale, "Utility Toolkit for MCP Teams", "Utility-набор для MCP-команд")}
+          description={tr(
             locale,
-            "Tools (Token Calculator / Rules Generator / Date & Time Localizer)",
-            "Инструменты (Калькулятор токенов / Генератор правил / Локализатор даты и времени)",
+            "Estimate prompt cost, generate delivery rules, and localize date-time formats for cross-regional operations.",
+            "Оценивайте стоимость промптов, генерируйте правила доставки и локализуйте дату/время для кросс-региональной работы.",
           )}
-        </h1>
-        <p className="text-sm text-slate-300">
-          {tr(
-            locale,
-            "Estimate prompt tokens, generate starter project rules, and convert US↔RU date/time formats.",
-            "Оценивайте токены в промптах, генерируйте стартовые правила проекта и конвертируйте форматы даты/времени США↔РФ.",
-          )}
-        </p>
+          actions={
+            <Button
+              asChild
+              variant="outline"
+              className="h-11 rounded-xl border-white/20 bg-slate-950/70 text-slate-100 hover:bg-slate-900"
+            >
+              <Link href="/how-to-use">{tr(locale, "How to use these tools", "Как использовать инструменты")}</Link>
+            </Button>
+          }
+        />
+        <div className="rounded-2xl border border-white/10 bg-slate-950/70 p-5 sm:p-6">
+          <ToolsSection />
+        </div>
       </div>
-      <ToolsSection />
-    </div>
+    </PageFrame>
   );
 }

--- a/components/catalog-filter-bar.tsx
+++ b/components/catalog-filter-bar.tsx
@@ -25,10 +25,12 @@ type CatalogFilterBarProps = {
   sortField: CatalogSortField;
   sortDirection: CatalogSortDirection;
   viewMode: CatalogViewMode;
+  activeFiltersCount?: number;
   onSearchQueryChange: (value: string) => void;
   onSortFieldChange: (value: CatalogSortField) => void;
   onSortDirectionChange: (value: CatalogSortDirection) => void;
   onViewModeChange: (value: CatalogViewMode) => void;
+  onClearAllFilters?: () => void;
 };
 
 export function CatalogFilterBar({
@@ -36,17 +38,19 @@ export function CatalogFilterBar({
   sortField,
   sortDirection,
   viewMode,
+  activeFiltersCount = 0,
   onSearchQueryChange,
   onSortFieldChange,
   onSortDirectionChange,
   onViewModeChange,
+  onClearAllFilters,
 }: CatalogFilterBarProps) {
   const locale = useLocale();
 
   return (
-    <div className="grid gap-3 lg:grid-cols-[1fr_170px_150px_auto]">
+    <div className="grid gap-3 rounded-2xl border border-white/10 bg-slate-950/70 p-3 lg:grid-cols-[1fr_170px_150px_auto] lg:items-center">
       <div className="relative">
-        <Search className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-slate-400" />
+        <Search className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-slate-500" />
         <Input
           value={searchQuery}
           onChange={(event) => onSearchQueryChange(event.target.value)}
@@ -55,12 +59,12 @@ export function CatalogFilterBar({
             "Search tools, features, or descriptions...",
             "Поиск по инструментам, фичам или описанию...",
           )}
-          className="h-10 border-slate-300 bg-white pl-9 text-slate-700 placeholder:text-slate-400"
+          className="h-10 border-white/15 bg-slate-900/90 pl-9 text-slate-100 placeholder:text-slate-500"
         />
       </div>
 
       <Select value={sortField} onValueChange={(value) => onSortFieldChange(value as CatalogSortField)}>
-        <SelectTrigger className="h-10 w-full border-slate-300 bg-white text-slate-700">
+        <SelectTrigger className="h-10 w-full border-white/15 bg-slate-900/90 text-slate-100">
           <SelectValue placeholder={tr(locale, "Sort by", "Сортировка")} />
         </SelectTrigger>
         <SelectContent>
@@ -74,7 +78,7 @@ export function CatalogFilterBar({
         value={sortDirection}
         onValueChange={(value) => onSortDirectionChange(value as CatalogSortDirection)}
       >
-        <SelectTrigger className="h-10 w-full border-slate-300 bg-white text-slate-700">
+        <SelectTrigger className="h-10 w-full border-white/15 bg-slate-900/90 text-slate-100">
           <SelectValue placeholder={tr(locale, "Order", "Порядок")} />
         </SelectTrigger>
         <SelectContent>
@@ -83,7 +87,7 @@ export function CatalogFilterBar({
         </SelectContent>
       </Select>
 
-      <div className="flex items-center justify-end gap-1 rounded-lg border border-slate-300 bg-white p-1">
+      <div className="flex items-center justify-end gap-1 rounded-lg border border-white/15 bg-slate-900/90 p-1">
         <Button
           type="button"
           size="icon-sm"
@@ -91,8 +95,8 @@ export function CatalogFilterBar({
           className={cn(
             "transition",
             viewMode === "grid"
-              ? "bg-blue-600 text-white hover:bg-blue-500"
-              : "text-slate-500 hover:text-slate-800",
+              ? "bg-blue-500 text-white hover:bg-blue-400"
+              : "text-slate-400 hover:text-slate-100",
           )}
           onClick={() => onViewModeChange("grid")}
           aria-label={tr(locale, "Grid view", "Вид сеткой")}
@@ -106,14 +110,31 @@ export function CatalogFilterBar({
           className={cn(
             "transition",
             viewMode === "list"
-              ? "bg-blue-600 text-white hover:bg-blue-500"
-              : "text-slate-500 hover:text-slate-800",
+              ? "bg-blue-500 text-white hover:bg-blue-400"
+              : "text-slate-400 hover:text-slate-100",
           )}
           onClick={() => onViewModeChange("list")}
           aria-label={tr(locale, "List view", "Вид списком")}
         >
           <List className="size-4" />
         </Button>
+      </div>
+
+      <div className="flex items-center gap-2 text-xs text-slate-300 lg:col-span-4">
+        <span className="rounded-full border border-white/10 bg-slate-900/80 px-2 py-0.5 text-[11px]">
+          {tr(locale, "Active filters", "Активные фильтры")}: {activeFiltersCount}
+        </span>
+        {onClearAllFilters ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="xs"
+            className="h-7 rounded-md px-2 text-slate-300 hover:bg-slate-800 hover:text-white"
+            onClick={onClearAllFilters}
+          >
+            {tr(locale, "Reset filters", "Сбросить фильтры")}
+          </Button>
+        ) : null}
       </div>
     </div>
   );

--- a/components/catalog-section.tsx
+++ b/components/catalog-section.tsx
@@ -1,12 +1,14 @@
 "use client";
 
-import { useMemo } from "react";
-import { SearchX } from "lucide-react";
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+import { GitCompareArrows, Heart, SearchX } from "lucide-react";
 
 import { CatalogFilterBar } from "@/components/catalog-filter-bar";
 import { CatalogTaxonomyPanel } from "@/components/catalog-taxonomy-panel";
 import { useLocale } from "@/components/locale-provider";
 import { ServerCard } from "@/components/server-card";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useCatalogState } from "@/hooks/use-catalog-state";
 import { getServerScore } from "@/lib/catalog/sorting";
@@ -23,8 +25,47 @@ type AuthTypeOption = {
   count: number;
 };
 
+const savedIdsStorageKey = "demumumind.savedServerIds";
+const compareIdsStorageKey = "demumumind.compareServerIds";
+const maxComparedServers = 3;
+
+function readStoredIds(storageKey: string, limit?: number): string[] {
+  if (typeof window === "undefined") {
+    return [];
+  }
+
+  try {
+    const rawValue = window.localStorage.getItem(storageKey);
+
+    if (!rawValue) {
+      return [];
+    }
+
+    const parsed = JSON.parse(rawValue);
+
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    const ids = parsed.filter((value): value is string => typeof value === "string");
+
+    if (typeof limit === "number") {
+      return ids.slice(0, limit);
+    }
+
+    return ids;
+  } catch {
+    return [];
+  }
+}
+
 export function CatalogSection({ initialServers }: CatalogSectionProps) {
   const locale = useLocale();
+  const [savedServerIds, setSavedServerIds] = useState<string[]>(() => readStoredIds(savedIdsStorageKey));
+  const [comparedServerIds, setComparedServerIds] = useState<string[]>(() =>
+    readStoredIds(compareIdsStorageKey, maxComparedServers),
+  );
+
   const {
     searchQuery,
     selectedCategories,
@@ -47,6 +88,29 @@ export function CatalogSection({ initialServers }: CatalogSectionProps) {
     clearAllFilters,
   } = useCatalogState(initialServers);
 
+  const comparedServers = useMemo(
+    () => comparedServerIds
+      .map((serverId) => initialServers.find((server) => server.id === serverId))
+      .filter((server): server is McpServer => Boolean(server)),
+    [comparedServerIds, initialServers],
+  );
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(savedIdsStorageKey, JSON.stringify(savedServerIds));
+    } catch {
+      // ignore storage errors in restricted environments
+    }
+  }, [savedServerIds]);
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(compareIdsStorageKey, JSON.stringify(comparedServerIds));
+    } catch {
+      // ignore storage errors in restricted environments
+    }
+  }, [comparedServerIds]);
+
   const authTypeOptions = useMemo<AuthTypeOption[]>(
     () => [
       {
@@ -68,26 +132,115 @@ export function CatalogSection({ initialServers }: CatalogSectionProps) {
     [authTypeCounts.api_key, authTypeCounts.none, authTypeCounts.oauth, locale],
   );
 
+  const activeFiltersCount =
+    selectedCategories.length +
+    selectedAuthTypes.length +
+    selectedTags.length +
+    (searchQuery.trim().length > 0 ? 1 : 0);
+
+  function toggleSaved(serverId: string) {
+    setSavedServerIds((current) => {
+      if (current.includes(serverId)) {
+        return current.filter((id) => id !== serverId);
+      }
+
+      return [...current, serverId];
+    });
+  }
+
+  function toggleCompared(serverId: string) {
+    setComparedServerIds((current) => {
+      if (current.includes(serverId)) {
+        return current.filter((id) => id !== serverId);
+      }
+
+      if (current.length >= maxComparedServers) {
+        return [...current.slice(1), serverId];
+      }
+
+      return [...current, serverId];
+    });
+  }
+
   return (
     <div className="space-y-4">
+      {comparedServers.length > 0 ? (
+        <Card className="border-blue-400/25 bg-blue-500/10 shadow-none">
+          <CardHeader className="pb-2">
+            <CardTitle className="flex items-center gap-2 text-lg text-blue-100">
+              <GitCompareArrows className="size-4" />
+              {tr(locale, "Compare shortlist", "Сравнение shortlist")} ({comparedServers.length}/
+              {maxComparedServers})
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3 text-sm">
+            <div className="grid gap-2 lg:grid-cols-3">
+              {comparedServers.map((server) => (
+                <div key={server.id} className="rounded-lg border border-blue-400/25 bg-slate-950/70 p-3">
+                  <p className="font-medium text-slate-100">{server.name}</p>
+                  <p className="mt-1 text-xs text-slate-400">{server.category}</p>
+                  <p className="mt-1 text-xs text-slate-300">
+                    {tr(locale, "Auth", "Авторизация")}: {server.authType}
+                  </p>
+                  <p className="text-xs text-slate-300">
+                    {tr(locale, "Tools", "Инструменты")}: {server.tools.length}
+                  </p>
+                  <div className="mt-2 flex items-center gap-2">
+                    <Button asChild size="xs" className="h-7 bg-blue-500 hover:bg-blue-400">
+                      <Link href={`/server/${server.slug}`}>{tr(locale, "Open", "Открыть")}</Link>
+                    </Button>
+                    <Button
+                      type="button"
+                      size="xs"
+                      variant="ghost"
+                      className="h-7 text-slate-300 hover:bg-slate-800 hover:text-slate-100"
+                      onClick={() => toggleCompared(server.id)}
+                    >
+                      {tr(locale, "Remove", "Убрать")}
+                    </Button>
+                  </div>
+                </div>
+              ))}
+            </div>
+            <Button
+              type="button"
+              size="xs"
+              variant="ghost"
+              className="h-7 text-blue-100 hover:bg-blue-500/20 hover:text-blue-50"
+              onClick={() => setComparedServerIds([])}
+            >
+              {tr(locale, "Clear compare list", "Очистить сравнение")}
+            </Button>
+          </CardContent>
+        </Card>
+      ) : null}
+
       <CatalogFilterBar
         searchQuery={searchQuery}
         sortField={sortField}
         sortDirection={sortDirection}
         viewMode={viewMode}
+        activeFiltersCount={activeFiltersCount}
         onSearchQueryChange={setSearchQuery}
         onSortFieldChange={setSortField}
         onSortDirectionChange={setSortDirection}
         onViewModeChange={setViewMode}
+        onClearAllFilters={clearAllFilters}
       />
 
-      <p className="text-sm text-slate-500">
+      <div className="flex flex-wrap items-center justify-between gap-2 text-sm">
+        <p className="text-slate-300">
         {tr(
           locale,
           `${filteredServers.length} tools found`,
           `Найдено инструментов: ${filteredServers.length}`,
         )}
-      </p>
+        </p>
+        <p className="inline-flex items-center gap-1 rounded-full border border-white/10 bg-slate-900/80 px-2 py-0.5 text-xs text-slate-400">
+          <Heart className="size-3.5" />
+          {tr(locale, "Saved", "Сохранено")}: {savedServerIds.length}
+        </p>
+      </div>
 
       <div className="grid gap-5 lg:grid-cols-[240px_1fr]">
         <CatalogTaxonomyPanel
@@ -117,18 +270,22 @@ export function CatalogSection({ initialServers }: CatalogSectionProps) {
                   mcpServer={mcpServer}
                   viewMode={viewMode}
                   score={getServerScore(mcpServer)}
+                  isSaved={savedServerIds.includes(mcpServer.id)}
+                  isCompared={comparedServerIds.includes(mcpServer.id)}
+                  onToggleSaved={toggleSaved}
+                  onToggleCompared={toggleCompared}
                 />
               ))}
             </div>
           ) : (
-            <Card className="border-slate-200 bg-white shadow-sm">
+            <Card className="border-white/10 bg-slate-900/70 shadow-none">
               <CardHeader>
-                <CardTitle className="flex items-center gap-2 text-slate-900">
-                  <SearchX className="size-4 text-slate-500" />
+                <CardTitle className="flex items-center gap-2 text-slate-100">
+                  <SearchX className="size-4 text-slate-400" />
                   {tr(locale, "No tools found", "Инструменты не найдены")}
                 </CardTitle>
               </CardHeader>
-              <CardContent className="text-sm text-slate-600">
+              <CardContent className="text-sm text-slate-300">
                 {tr(
                   locale,
                   "Try another search query or reset categories/tags/access filters.",

--- a/components/catalog-taxonomy-panel.tsx
+++ b/components/catalog-taxonomy-panel.tsx
@@ -98,89 +98,89 @@ export function CatalogTaxonomyPanel(props: CatalogTaxonomyPanelProps) {
 
   if (isFilterMode(props)) {
     return (
-      <aside className="h-fit overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm lg:sticky lg:top-24">
+      <aside className="h-fit overflow-hidden rounded-2xl border border-white/10 bg-slate-950/72 shadow-[0_0_0_1px_rgba(148,163,184,0.08)] lg:sticky lg:top-24">
         <div className="flex items-center justify-between px-4 py-4">
-          <h2 className="text-lg font-semibold text-slate-900">{tr(localeFromContext, "Filters", "Фильтры")}</h2>
+          <h2 className="text-lg font-semibold text-slate-100">{tr(localeFromContext, "Filters", "Фильтры")}</h2>
           <button
             type="button"
-            className="text-xs font-medium text-slate-500 transition hover:text-slate-900"
+            className="text-xs font-medium text-slate-400 transition hover:text-slate-100"
             onClick={props.onClearAll}
           >
             {tr(localeFromContext, "Clear All", "Сбросить")}
           </button>
         </div>
 
-        <div className="border-t border-slate-200 px-4 py-4">
-          <h3 className="mb-2 text-sm font-semibold text-slate-800">
+        <div className="border-t border-white/10 px-4 py-4">
+          <h3 className="mb-2 text-sm font-semibold text-slate-100">
             {tr(localeFromContext, "Categories", "Категории")}
           </h3>
           <div className="max-h-52 space-y-1 overflow-y-auto pr-1">
             {props.categoryEntries.map(([categoryName, count]) => (
               <label
                 key={categoryName}
-                className="flex cursor-pointer items-center justify-between rounded-md px-1.5 py-1.5 transition hover:bg-slate-50"
+                className="flex cursor-pointer items-center justify-between rounded-md px-1.5 py-1.5 transition hover:bg-slate-900"
               >
                 <span className="inline-flex items-center gap-2">
                   <input
                     type="checkbox"
-                    className="size-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500"
+                    className="size-4 rounded border-slate-500 bg-slate-900 text-blue-500 focus:ring-blue-500"
                     checked={props.selectedCategories.includes(categoryName)}
                     onChange={() => props.onToggleCategory(categoryName)}
                   />
-                  <span className="text-sm text-slate-700">{categoryName}</span>
+                  <span className="text-sm text-slate-300">{categoryName}</span>
                 </span>
-                <span className="text-xs text-slate-400">{count}</span>
+                <span className="text-xs text-slate-500">{count}</span>
               </label>
             ))}
           </div>
         </div>
 
-        <div className="border-t border-slate-200 px-4 py-4">
-          <h3 className="mb-2 text-sm font-semibold text-slate-800">
+        <div className="border-t border-white/10 px-4 py-4">
+          <h3 className="mb-2 text-sm font-semibold text-slate-100">
             {tr(localeFromContext, "Pricing", "Стоимость")}
           </h3>
           <div className="space-y-1">
             {props.authTypeOptions.map((option) => (
               <label
                 key={option.value}
-                className="flex cursor-pointer items-center justify-between rounded-md px-1.5 py-1.5 transition hover:bg-slate-50"
+                className="flex cursor-pointer items-center justify-between rounded-md px-1.5 py-1.5 transition hover:bg-slate-900"
               >
                 <span className="inline-flex items-center gap-2">
                   <input
                     type="checkbox"
-                    className="size-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500"
+                    className="size-4 rounded border-slate-500 bg-slate-900 text-blue-500 focus:ring-blue-500"
                     checked={props.selectedAuthTypes.includes(option.value)}
                     onChange={() => props.onToggleAuthType(option.value)}
                   />
-                  <span className="text-sm text-slate-700">{option.label}</span>
+                  <span className="text-sm text-slate-300">{option.label}</span>
                 </span>
-                <span className="text-xs text-slate-400">{option.count}</span>
+                <span className="text-xs text-slate-500">{option.count}</span>
               </label>
             ))}
           </div>
         </div>
 
-        <div className="border-t border-slate-200 px-4 py-4">
-          <h3 className="mb-2 text-sm font-semibold text-slate-800">
+        <div className="border-t border-white/10 px-4 py-4">
+          <h3 className="mb-2 text-sm font-semibold text-slate-100">
             {tr(localeFromContext, "Tags", "Теги")}
           </h3>
           <div className="max-h-56 space-y-1 overflow-y-auto pr-1">
             {props.tagEntries.slice(0, CATALOG_VISIBLE_TAG_LIMIT).map(([tag, count]) => (
               <label
                 key={tag}
-                className="flex cursor-pointer items-center justify-between rounded-md px-1.5 py-1.5 transition hover:bg-slate-50"
+                className="flex cursor-pointer items-center justify-between rounded-md px-1.5 py-1.5 transition hover:bg-slate-900"
               >
                 <span className="inline-flex items-center gap-2">
                   <input
                     type="checkbox"
-                    className="size-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500"
+                    className="size-4 rounded border-slate-500 bg-slate-900 text-blue-500 focus:ring-blue-500"
                     checked={props.selectedTags.includes(tag)}
                     onChange={() => props.onToggleTag(tag)}
                   />
                   <span className={cn("inline-block size-2 rounded-full", getTagDotClass(tag))} />
-                  <span className="text-sm text-slate-700">{tag}</span>
+                  <span className="text-sm text-slate-300">{tag}</span>
                 </span>
-                <span className="text-xs text-slate-400">{count}</span>
+                <span className="text-xs text-slate-500">{count}</span>
               </label>
             ))}
           </div>

--- a/components/page-templates.tsx
+++ b/components/page-templates.tsx
@@ -1,0 +1,121 @@
+import type { ReactNode } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+
+type PageFrameVariant = "marketing" | "directory" | "form" | "content" | "ops";
+
+const frameClassByVariant: Record<PageFrameVariant, string> = {
+  marketing:
+    "bg-[linear-gradient(180deg,#030812_0%,#040b17_45%,#04070f_100%)] before:bg-[radial-gradient(circle_at_15%_0%,rgba(56,189,248,0.2),transparent_40%),radial-gradient(circle_at_85%_5%,rgba(59,130,246,0.15),transparent_36%)]",
+  directory:
+    "bg-[linear-gradient(180deg,#030816_0%,#050b1a_52%,#050913_100%)] before:bg-[radial-gradient(circle_at_12%_4%,rgba(34,211,238,0.2),transparent_42%),radial-gradient(circle_at_88%_0%,rgba(14,165,233,0.16),transparent_38%)]",
+  form: "bg-[linear-gradient(180deg,#0a0716_0%,#090a1a_48%,#060814_100%)] before:bg-[radial-gradient(circle_at_20%_0%,rgba(217,70,239,0.2),transparent_42%),radial-gradient(circle_at_78%_5%,rgba(99,102,241,0.16),transparent_40%)]",
+  content:
+    "bg-[linear-gradient(180deg,#050c1c_0%,#060a16_50%,#040810_100%)] before:bg-[radial-gradient(circle_at_14%_2%,rgba(139,92,246,0.2),transparent_42%),radial-gradient(circle_at_86%_4%,rgba(56,189,248,0.14),transparent_40%)]",
+  ops: "bg-[linear-gradient(180deg,#060a14_0%,#070c18_48%,#050913_100%)] before:bg-[radial-gradient(circle_at_18%_3%,rgba(16,185,129,0.2),transparent_42%),radial-gradient(circle_at_82%_2%,rgba(59,130,246,0.14),transparent_36%)]",
+};
+
+type PageFrameProps = {
+  children: ReactNode;
+  className?: string;
+  variant?: PageFrameVariant;
+};
+
+export function PageFrame({ children, className, variant = "marketing" }: PageFrameProps) {
+  return (
+    <div
+      className={cn(
+        "relative overflow-hidden border-t border-white/10 before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:-z-10 before:h-[520px] before:content-['']",
+        frameClassByVariant[variant],
+        className,
+      )}
+    >
+      <div className="pointer-events-none absolute inset-0 -z-10 bg-[linear-gradient(90deg,rgba(56,189,248,0.06)_1px,transparent_1px),linear-gradient(rgba(56,189,248,0.05)_1px,transparent_1px)] bg-[size:44px_44px] opacity-30" />
+      {children}
+    </div>
+  );
+}
+
+type PageHeroProps = {
+  title: string;
+  description: string;
+  eyebrow?: string;
+  badgeTone?: "cyan" | "emerald" | "violet" | "amber";
+  actions?: ReactNode;
+  metrics?: ReactNode;
+  className?: string;
+};
+
+const badgeClassByTone: Record<NonNullable<PageHeroProps["badgeTone"]>, string> = {
+  cyan: "border-cyan-400/40 bg-cyan-500/10 text-cyan-200",
+  emerald: "border-emerald-400/40 bg-emerald-500/10 text-emerald-200",
+  violet: "border-violet-400/40 bg-violet-500/10 text-violet-200",
+  amber: "border-amber-400/40 bg-amber-500/10 text-amber-200",
+};
+
+export function PageHero({
+  title,
+  description,
+  eyebrow,
+  badgeTone = "cyan",
+  actions,
+  metrics,
+  className,
+}: PageHeroProps) {
+  return (
+    <section
+      className={cn(
+        "rounded-3xl border border-white/10 bg-slate-950/72 px-5 py-6 shadow-[0_0_0_1px_rgba(148,163,184,0.08)] sm:px-8 sm:py-9",
+        className,
+      )}
+    >
+      <div className="space-y-4">
+        {eyebrow ? <Badge className={badgeClassByTone[badgeTone]}>{eyebrow}</Badge> : null}
+        <div className="space-y-3">
+          <h1 className="text-4xl leading-[0.98] font-semibold tracking-tight text-slate-100 sm:text-5xl lg:text-6xl">
+            {title}
+          </h1>
+          <p className="max-w-4xl text-sm leading-7 text-slate-300 sm:text-base sm:leading-8">
+            {description}
+          </p>
+        </div>
+        {actions ? <div className="flex flex-wrap items-center gap-3">{actions}</div> : null}
+        {metrics ? <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">{metrics}</div> : null}
+      </div>
+    </section>
+  );
+}
+
+type PageSectionProps = {
+  children: ReactNode;
+  className?: string;
+};
+
+export function PageSection({ children, className }: PageSectionProps) {
+  return (
+    <section
+      className={cn(
+        "rounded-2xl border border-white/10 bg-slate-950/70 p-5 shadow-[0_0_0_1px_rgba(148,163,184,0.06)] sm:p-6",
+        className,
+      )}
+    >
+      {children}
+    </section>
+  );
+}
+
+type PageMetricProps = {
+  label: string;
+  value: ReactNode;
+  valueClassName?: string;
+};
+
+export function PageMetric({ label, value, valueClassName }: PageMetricProps) {
+  return (
+    <div className="rounded-xl border border-white/10 bg-slate-900/70 px-4 py-3">
+      <p className="text-[11px] tracking-[0.14em] text-slate-400 uppercase">{label}</p>
+      <p className={cn("mt-1 text-2xl font-semibold text-slate-100", valueClassName)}>{value}</p>
+    </div>
+  );
+}

--- a/components/server-card.tsx
+++ b/components/server-card.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import Link from "next/link";
-import { useMemo, useState } from "react";
-import { Heart, Star } from "lucide-react";
+import { useMemo } from "react";
+import { GitCompareArrows, Heart, Star } from "lucide-react";
 
 import { useLocale } from "@/components/locale-provider";
 import { Badge } from "@/components/ui/badge";
@@ -18,6 +18,10 @@ type ServerCardProps = {
   mcpServer: McpServer;
   viewMode?: ServerCardViewMode;
   score?: number;
+  isSaved?: boolean;
+  isCompared?: boolean;
+  onToggleSaved?: (serverId: string) => void;
+  onToggleCompared?: (serverId: string) => void;
 };
 
 type LogoStyle = {
@@ -135,9 +139,16 @@ function getRatingValue(mcpServer: McpServer, score?: number): number {
   return Math.max(1, Math.min(5, Number(normalized.toFixed(1))));
 }
 
-export function ServerCard({ mcpServer, viewMode = "grid", score }: ServerCardProps) {
+export function ServerCard({
+  mcpServer,
+  viewMode = "grid",
+  score,
+  isSaved = false,
+  isCompared = false,
+  onToggleSaved,
+  onToggleCompared,
+}: ServerCardProps) {
   const locale = useLocale();
-  const [saved, setSaved] = useState(false);
 
   const rating = useMemo(() => getRatingValue(mcpServer, score), [mcpServer, score]);
   const logoStyle = useMemo(() => resolveLogoStyle(mcpServer), [mcpServer]);
@@ -148,13 +159,13 @@ export function ServerCard({ mcpServer, viewMode = "grid", score }: ServerCardPr
   return (
     <Card
       className={cn(
-        "overflow-hidden border-slate-200 bg-white shadow-sm transition duration-200 hover:border-blue-300 hover:shadow-md",
+        "overflow-hidden border-white/10 bg-slate-900/75 shadow-[0_0_0_1px_rgba(148,163,184,0.08)] transition duration-200 hover:border-cyan-400/35",
         viewMode === "list" && "md:grid md:grid-cols-[250px_1fr]",
       )}
     >
       <div
         className={cn(
-          "relative overflow-hidden border-b border-slate-200 bg-gradient-to-br p-3",
+          "relative overflow-hidden border-b border-white/10 bg-gradient-to-br p-3",
           accentClassByLevel[mcpServer.verificationLevel],
           viewMode === "grid" ? "h-44" : "md:h-full md:border-r md:border-b-0",
         )}
@@ -175,11 +186,22 @@ export function ServerCard({ mcpServer, viewMode = "grid", score }: ServerCardPr
                 aria-label={tr(locale, "Save card", "Сохранить карточку")}
                 className={cn(
                   "inline-flex size-7 items-center justify-center rounded-md border border-slate-200/80 bg-white/90 text-slate-500 transition hover:text-rose-500",
-                  saved && "text-rose-500",
+                  isSaved && "text-rose-500",
                 )}
-                onClick={() => setSaved((isSaved) => !isSaved)}
+                onClick={() => onToggleSaved?.(mcpServer.id)}
               >
-                <Heart className={cn("size-3.5", saved && "fill-current")} />
+                <Heart className={cn("size-3.5", isSaved && "fill-current")} />
+              </button>
+              <button
+                type="button"
+                aria-label={tr(locale, "Add to compare", "Добавить в сравнение")}
+                className={cn(
+                  "inline-flex size-7 items-center justify-center rounded-md border border-slate-200/80 bg-white/90 text-slate-500 transition hover:text-blue-600",
+                  isCompared && "text-blue-600",
+                )}
+                onClick={() => onToggleCompared?.(mcpServer.id)}
+              >
+                <GitCompareArrows className={cn("size-3.5", isCompared && "stroke-[2.8]")} />
               </button>
             </div>
           </div>
@@ -199,15 +221,15 @@ export function ServerCard({ mcpServer, viewMode = "grid", score }: ServerCardPr
 
       <div className="flex flex-1 flex-col">
         <CardHeader className="space-y-2 pb-2">
-          <CardTitle className="text-lg leading-tight text-slate-900">
-            <Link className="transition hover:text-blue-600" href={`/server/${mcpServer.slug}`}>
+          <CardTitle className="text-lg leading-tight text-slate-100">
+            <Link className="transition hover:text-cyan-200" href={`/server/${mcpServer.slug}`}>
               {mcpServer.name}
             </Link>
           </CardTitle>
-          <p className="text-xs text-slate-500">
+          <p className="text-xs text-slate-400">
             {tr(locale, "by", "от")} {mcpServer.maintainer?.name ?? mcpServer.name}
           </p>
-          <p className="line-clamp-2 text-sm text-slate-600">{mcpServer.description}</p>
+          <p className="line-clamp-2 text-sm text-slate-300">{mcpServer.description}</p>
         </CardHeader>
 
         <CardContent className="space-y-3 pt-0">
@@ -215,34 +237,34 @@ export function ServerCard({ mcpServer, viewMode = "grid", score }: ServerCardPr
             {mcpServer.tags.slice(0, 3).map((tag) => (
               <span
                 key={tag}
-                className="rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-xs text-slate-500"
+                className="rounded-full border border-white/15 bg-slate-800/80 px-2 py-0.5 text-xs text-slate-300"
               >
                 {tag}
               </span>
             ))}
             {mcpServer.tags.length > 3 ? (
-              <span className="rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-xs text-slate-500">
+              <span className="rounded-full border border-white/15 bg-slate-800/80 px-2 py-0.5 text-xs text-slate-300">
                 +{mcpServer.tags.length - 3}
               </span>
             ) : null}
           </div>
 
           <div className="flex items-center justify-between">
-            <div className="inline-flex items-center gap-1 rounded-full bg-amber-50 px-2 py-1 text-xs font-medium text-amber-700">
+            <div className="inline-flex items-center gap-1 rounded-full border border-amber-400/30 bg-amber-500/10 px-2 py-1 text-xs font-medium text-amber-200">
               <Star className="size-3.5 fill-current" />
               {rating.toFixed(1)}
             </div>
-            <span className="text-sm font-semibold text-blue-600">
+            <span className="text-sm font-semibold text-cyan-200">
               {tr(locale, accessLabel.en, accessLabel.ru)}
             </span>
           </div>
         </CardContent>
 
-        <CardFooter className="mt-auto border-t border-slate-200 bg-slate-50/80 p-3">
+        <CardFooter className="mt-auto border-t border-white/10 bg-slate-900/90 p-3">
           <Button
             asChild
             variant="outline"
-            className="w-full border-slate-200 bg-white text-slate-700 hover:bg-slate-100"
+            className="w-full border-white/15 bg-slate-950/70 text-slate-100 hover:bg-slate-900"
           >
             <Link href={`/server/${mcpServer.slug}`}>
               {tr(locale, "View Details", "Подробнее")}

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import {
   type LucideIcon,
   BookOpen,
@@ -19,7 +20,8 @@ import { AuthNavActions } from "@/components/auth-nav-actions";
 import { BrandLockup } from "@/components/brand-lockup";
 import { LanguageSwitcher } from "@/components/language-switcher";
 import { ThemeToggle } from "@/components/theme-toggle";
-import type { Locale } from "@/lib/i18n";
+import { tr, type Locale } from "@/lib/i18n";
+import { cn } from "@/lib/utils";
 
 type NavLinkItem = {
   href: string;
@@ -45,6 +47,7 @@ type SiteHeaderProps = {
 };
 
 export function SiteHeader({ locale }: SiteHeaderProps) {
+  const pathname = usePathname();
   const navLinks = navLinkMap.map((item) => ({
     href: item.href,
     label: item.label[locale],
@@ -53,6 +56,20 @@ export function SiteHeader({ locale }: SiteHeaderProps) {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const menuLabel = locale === "en" ? "Menu" : "Меню";
   const closeLabel = locale === "en" ? "Close menu" : "Закрыть меню";
+  const catalogCtaLabel = tr(locale, "Catalog", "Каталог");
+  const submitCtaLabel = tr(locale, "Submit", "Отправить");
+
+  function isNavLinkActive(href: string): boolean {
+    if (!pathname) {
+      return false;
+    }
+
+    if (href === "/") {
+      return pathname === "/";
+    }
+
+    return pathname === href || pathname.startsWith(`${href}/`);
+  }
 
   useEffect(() => {
     if (!isMobileMenuOpen) {
@@ -90,7 +107,12 @@ export function SiteHeader({ locale }: SiteHeaderProps) {
             <Link
               key={link.href}
               href={link.href}
-              className="inline-flex items-center gap-1.5 rounded-md px-1.5 py-1 text-xs tracking-wide text-slate-300 transition-colors hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/80 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950"
+              className={cn(
+                "inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs tracking-wide transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/80 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950",
+                isNavLinkActive(link.href)
+                  ? "bg-cyan-500/12 text-cyan-200"
+                  : "text-slate-300 hover:text-white",
+              )}
             >
               <link.icon aria-hidden className="size-3.5 opacity-85" />
               {link.label}
@@ -99,6 +121,20 @@ export function SiteHeader({ locale }: SiteHeaderProps) {
         </nav>
 
         <div className="flex shrink-0 items-center gap-2">
+          <div className="hidden items-center gap-2 xl:flex">
+            <Link
+              href="/catalog"
+              className="inline-flex h-9 items-center rounded-md border border-white/15 bg-slate-900/70 px-3 text-xs font-medium text-slate-100 transition hover:bg-slate-900"
+            >
+              {catalogCtaLabel}
+            </Link>
+            <Link
+              href="/submit-server"
+              className="inline-flex h-9 items-center rounded-md bg-blue-500 px-3 text-xs font-semibold text-white transition hover:bg-blue-400"
+            >
+              {submitCtaLabel}
+            </Link>
+          </div>
           <button
             type="button"
             className="inline-flex h-11 min-w-11 items-center justify-center rounded-full border border-white/15 bg-slate-900/70 px-3 text-slate-300 transition hover:bg-slate-900 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/80 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 lg:hidden"
@@ -138,6 +174,26 @@ export function SiteHeader({ locale }: SiteHeaderProps) {
                 {link.label}
               </Link>
             ))}
+            <div className="mt-2 grid gap-2 border-t border-white/10 pt-3">
+              <Link
+                href="/catalog"
+                onClick={() => {
+                  setIsMobileMenuOpen(false);
+                }}
+                className="inline-flex min-h-11 items-center justify-center rounded-lg border border-white/15 bg-slate-900/70 px-3 text-sm font-medium text-slate-100 transition hover:bg-slate-900"
+              >
+                {catalogCtaLabel}
+              </Link>
+              <Link
+                href="/submit-server"
+                onClick={() => {
+                  setIsMobileMenuOpen(false);
+                }}
+                className="inline-flex min-h-11 items-center justify-center rounded-lg bg-blue-500 px-3 text-sm font-semibold text-white transition hover:bg-blue-400"
+              >
+                {submitCtaLabel}
+              </Link>
+            </div>
           </div>
         </nav>
       ) : null}


### PR DESCRIPTION
﻿## Summary
This PR rolls out the homepage visual language across the full site for a consistent redesign.

## Included commits
- 1fa499a — feat(redesign): roll out homepage-style UI across core pages
- 69a2a90 — feat(redesign): extend homepage style to remaining pages
- a1bcbee — feat(redesign): align account and admin blog with page frame

## What changed
### Core redesign rollout
- Updated core pages to the homepage style system:
  - admin/login, admin, auth/*, catalog, categories, mcp, pricing, privacy, server/[slug], sitemap, terms, tools
- Updated shared UI pieces:
  - components/page-templates.tsx
  - components/site-header.tsx
  - components/server-card.tsx
  - components/catalog-section.tsx
  - components/catalog-filter-bar.tsx
  - components/catalog-taxonomy-panel.tsx

### Remaining public pages aligned
- about, account, blog list, blog slug, contact, discord, how-to-use, submit-server

### Admin/account completion
- account page now uses the unified page frame variant
- admin/blog now uses the unified page frame variant and spacing rhythm aligned with the rest of admin UI

## Scope / non-goals
- No backend/API contract changes.
- No auth/business logic rewrite.
- Focused on UI consistency and visual unification.

## Verification
- 
pm run check:utf8:strict ✅
- 
pm run lint -- --max-warnings=0 ✅
- 
pm run build ✅
- Playwright manual spot-checks on local dev:
  - /admin/login?redirect=/admin/blog -> login with fallback token local-admin-token -> /admin/blog render verified
  - /account unauthenticated redirect flow verified to auth surface

## Risk and rollback
- Risk level: low–medium (UI-only wide surface).
- Rollback: revert commits 1bcbee, 69a2a90, and 1fa499a.
