### PR TITLE
fix(deploy): install Playwright browser before auth E2E

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,7 +66,13 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
       - name: Auth E2E (Playwright)
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: http://127.0.0.1:54321
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: test-anon-key
         run: npm run test:e2e:auth
 
       - name: Resolve deployment mode


### PR DESCRIPTION
## Summary
- add Playwright browser installation to Deploy workflow before auth E2E
- add test auth env placeholders for Deploy workflow auth E2E step (same pattern as CI)

## Why
Deploy workflow on main failed during Auth E2E (Playwright) because Chromium was not installed in that job.

## Verification
- npm run lint
- npm run build